### PR TITLE
Make file with snake_case

### DIFF
--- a/lib/generation/flutter_project_builder/flutter_project_builder.dart
+++ b/lib/generation/flutter_project_builder/flutter_project_builder.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:archive/archive.dart';
+import 'package:recase/recase.dart';
 import 'package:parabeac_core/controllers/main_info.dart';
 import 'package:parabeac_core/generation/generators/pb_flutter_generator.dart';
 import 'package:parabeac_core/generation/generators/pb_flutter_writer.dart';
@@ -173,7 +174,7 @@ class FlutterProjectBuilder {
     var pageWriter = PBFlutterWriter();
 
     for (var directory in mainTree.groups) {
-      var directoryName = directory.name.toLowerCase().replaceAll(' ', '_');
+      var directoryName = directory.name.snakeCase;
       var flutterGenerator;
       var importSet = <String>[];
       var bodyBuffer, constructorBuffer;
@@ -196,9 +197,9 @@ class FlutterProjectBuilder {
 
         var name = isSymbolsDir ? SYMBOL_DIR_NAME : fileName;
         var symbolFilePath =
-            '${projectName}/lib/screens/${directoryName}/${name.toLowerCase()}.dart';
+            '${projectName}/lib/screens/${directoryName}/${name.snakeCase}.dart';
         var fileNamePath =
-            '${projectName}/lib/screens/${directoryName}/${fileName.toLowerCase()}.dart';
+            '${projectName}/lib/screens/${directoryName}/${fileName.snakeCase}.dart';
         // TODO: Need FlutterGenerator for each page because otherwise
         // we'd add all imports to every single dart page. Discuss alternatives
         if (!isSymbolsDir) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   analyzer: ^0.39.15
   quick_log: ^1.1.3
   sentry: ">=3.0.0 <4.0.0"
+  recase: "^3.0.0"
 #  path: ^1.6.0
 
 dev_dependencies:


### PR DESCRIPTION
based on [Effective Dart : DO name libraries, packages, directories, and source files using lowercase_with_underscores](https://dart.dev/guides/language/effective-dart/style#do-name-libraries-and-source-files-using-lowercase_with_underscores) generated files should have snake_case. Many files using `toLowerCase().replaceAll(' ', '_')` this code, it is not bad but can change more better. so I using [recase](https://pub.dev/packages/recase) for make file name with snake_case.

Before

![image](https://user-images.githubusercontent.com/1451365/93979633-92631c00-fdb8-11ea-951c-c29dc342fa68.png)

After

![image](https://user-images.githubusercontent.com/1451365/93980133-3056e680-fdb9-11ea-9332-48ca59ae4421.png)




---

recase showcase.

```dart
import 'package:recase/recase.dart';

void main(List<String> arguments) {
  print(ReCase('Hello World').snakeCase);
  print(ReCase('HelloWorld').snakeCase);
  print(ReCase('hello_world').snakeCase);
  print(ReCase('hello World').snakeCase);
  print(ReCase('Hello   World').snakeCase);
  print(ReCase('_Hello World').snakeCase);
}
```

```sh
# All the same hello_world
hello_world
hello_world
hello_world
hello_world
hello_world
hello_world
```
