### PR TITLE
Format code when project created

### DIFF
--- a/lib/generation/flutter_project_builder/flutter_project_builder.dart
+++ b/lib/generation/flutter_project_builder/flutter_project_builder.dart
@@ -121,6 +121,19 @@ class FlutterProjectBuilder {
         runInShell: true,
         environment: Platform.environment,
         workingDirectory: '${MainInfo().outputPath}');
+
+    log.info(
+      Process.runSync(
+              'dartfmt',
+              [
+                '-w',
+                '${pathToFlutterProject}bin',
+                '${pathToFlutterProject}lib',
+                '${pathToFlutterProject}test'
+              ],
+              workingDirectory: MainInfo().outputPath)
+          .stdout,
+    );
   }
 
   /// Traverse the [node] tree, check if any nodes need importing,


### PR DESCRIPTION
First time when open generated codes, I saw unformatted code. It feel bad. It depends on #33 like a Developer Experience.
So, run dartfmt when project created successfully. 


## before format HomeScreen
![image](https://user-images.githubusercontent.com/1451365/94113310-ab83cf80-fe81-11ea-9d5e-c6dea7c2a71f.png)

formatted code is better than this one.

## after format HomeScreen
![image](https://user-images.githubusercontent.com/1451365/94113246-8c853d80-fe81-11ea-9e7d-5b1e8f3cbec5.png)



