### PR TITLE
refactor: generateState[ful|less]Widget using multiline text

### DIFF
--- a/lib/generation/generators/pb_flutter_generator.dart
+++ b/lib/generation/generators/pb_flutter_generator.dart
@@ -45,7 +45,7 @@ class _${widgetName} extends State<${widgetName}>{
 }''';
   }
 
-  String generateStatelessWidgets(String body, String name) {
+  String generateStatelessWidget(String body, String name) {
     var widgetName = _generateWidgetName(name);
     var constructorName = '_$name';
     return '''
@@ -145,7 +145,7 @@ class ${widgetName} extends StatelessWidget{
           return generateStatefulWidget(gen.generate(rootNode), rootNode.name);
           break;
         case BUILDER_TYPE.STATELESS_WIDGET:
-          return generateStatelessWidgets(
+          return generateStatelessWidget(
               gen.generate(rootNode), rootNode.name);
           break;
         case BUILDER_TYPE.EMPTY_PAGE:

--- a/lib/generation/generators/pb_flutter_generator.dart
+++ b/lib/generation/generators/pb_flutter_generator.dart
@@ -23,34 +23,51 @@ class PBFlutterGenerator extends PBGenerationManager {
   }
 
   String generateStatefulWidget(String body, String name) {
-    name = PBInputFormatter.formatLabel(name,
-        isTitle: true, space_to_underscore: false);
-    var widgetName = name;
+    var widgetName = _generateWidgetName(name);
     var constructorName = '_$name';
-    var buffer = StringBuffer();
-    buffer.write('class ${widgetName} extends StatefulWidget{\n'
-        '\tconst ${widgetName}() : super();\n'
-        '@override\n_${widgetName} createState() => _${widgetName}();\n}\n\n'
-        'class _${widgetName} extends State<${widgetName}>{\n'
-        '${generateInstanceVariables()}\n'
-        '${generateConstructor(constructorName)}\n'
-        '@override\nWidget build(BuildContext context){\n'
-        'return ${body};\n}\n}');
-    return generateImports() + buffer.toString();
+    return '''
+${generateImports()}
+
+class ${widgetName} extends StatefulWidget{
+  const ${widgetName}() : super();
+  @override
+  _${widgetName} createState() => _${widgetName}();
+}
+
+class _${widgetName} extends State<${widgetName}>{
+  ${generateInstanceVariables()}
+  ${generateConstructor(constructorName)}
+
+  @override
+  Widget build(BuildContext context){
+    return ${body};
+  }
+}''';
   }
 
   String generateStatelessWidgets(String body, String name) {
-    name = PBInputFormatter.formatLabel(name,
-        isTitle: true, space_to_underscore: false);
-    var buffer = StringBuffer();
+    var widgetName = _generateWidgetName(name);
     var constructorName = '_$name';
-    buffer.write('class ${name} extends StatelessWidget{\n'
-        '\tconst ${name}({Key key}) : super(key : key);\n'
-        '${generateInstanceVariables()}\n'
-        '${generateConstructor(constructorName)}\n'
-        '\t@override\n\tWidget build(BuildContext context){\n\t return ${body};}}');
-    return generateImports() + buffer.toString();
+    return '''
+${generateImports()}
+
+class ${widgetName} extends StatelessWidget{
+  const ${widgetName}({Key key}) : super(key : key);
+  ${generateInstanceVariables()}
+  ${generateConstructor(constructorName)}
+
+  @override
+  Widget build(BuildContext context){
+    return ${body};
   }
+}''';
+  }
+
+  String _generateWidgetName(name) => PBInputFormatter.formatLabel(
+        name,
+        isTitle: true,
+        space_to_underscore: false,
+      );
 
   String generateConstructor(name) {
     if (constructorVariables == null || constructorVariables.isEmpty) {


### PR DESCRIPTION
Dart supports multiline text. I remain other codes using StringBuffer. I thought StringBuffer is a good option but `generateStatefulWidget` and `generateStatelessWidget` with multiline is easy to read.
This PR depends on my experience (Sometimes I forgot \t or quote). I respect Parabeac member's code rules.