### PR TITLE
Remove unused property in PBIntermediateNode

### DIFF
--- a/lib/interpret_and_optimize/entities/subclasses/pb_intermediate_node.dart
+++ b/lib/interpret_and_optimize/entities/subclasses/pb_intermediate_node.dart
@@ -16,8 +16,6 @@ abstract class PBIntermediateNode {
   @JsonKey(ignore: true)
   BUILDER_TYPE builder_type;
 
-  String widgetType;
-
   @JsonKey(ignore: true)
   PBGenerator generator;
 


### PR DESCRIPTION
I was hoping to fix #31  .
I just remove the property and didnt find any usage of the property in the project.
