### PR TITLE
Fixes zero'ing out statement variable if scaffold.background color is…

### DIFF
--- a/lib/generation/generators/attribute-helper/pb_color_gen_helper.dart
+++ b/lib/generation/generators/attribute-helper/pb_color_gen_helper.dart
@@ -21,8 +21,8 @@ class PBColorGenHelper extends PBAttributesHelper {
             ? 'backgroundColor: ${findDefaultColor(scaffold.backgroundColor)},'
             : 'backgroundColor: Color(${scaffold.backgroundColor}),\n';
       }
-    }
-    if (source.color == null) {
+
+    } else if (source.color == null) {
       statement = '';
     } else {
       if (source is! InheritedContainer) {


### PR DESCRIPTION
… used

if there is a background color for scaffold type, it is set to output background: Color(XX).  But if the source has color == null it immediately zeros out that statement = '' overwriting the scaffold background: Color(XX).

Now routine is setting the background color like it should.
