### PR TITLE
Egg for Back Arrow

### DIFF
--- a/lib/eggs/injected_back_arrow.dart
+++ b/lib/eggs/injected_back_arrow.dart
@@ -1,0 +1,53 @@
+import 'package:parabeac_core/design_logic/design_node.dart';
+import 'package:parabeac_core/generation/generators/pb_generator.dart';
+import 'package:parabeac_core/generation/generators/plugins/pb_plugin_node.dart';
+import 'package:parabeac_core/interpret_and_optimize/entities/interfaces/pb_injected_intermediate.dart';
+import 'package:parabeac_core/interpret_and_optimize/entities/subclasses/pb_intermediate_node.dart';
+import 'package:parabeac_core/interpret_and_optimize/helpers/pb_context.dart';
+import 'package:parabeac_core/interpret_and_optimize/value_objects/point.dart';
+
+class InjectedBackArrow extends PBEgg implements PBInjectedIntermediate {
+  @override
+  PBContext currentContext;
+
+  @override
+  final String UUID;
+
+  @override
+  String semanticName = '.*back-arrow';
+
+  InjectedBackArrow(
+      Point topLeftCorner, Point bottomRightCorner, this.UUID, String name,
+      {this.currentContext})
+      : super(topLeftCorner, bottomRightCorner, currentContext, name) {
+    generator = PBBackArrowGenerator();
+  }
+
+  @override
+  void addChild(PBIntermediateNode node) {}
+
+  @override
+  void alignChild() {}
+
+  @override
+  void extractInformation(DesignNode incomingNode) {}
+
+  @override
+  PBEgg generatePluginNode(
+      Point topLeftCorner, Point bottomRightCorner, DesignNode originalRef) {
+    return InjectedBackArrow(
+        topLeftCorner, bottomRightCorner, UUID, originalRef.name,
+        currentContext: currentContext);
+  }
+}
+
+class PBBackArrowGenerator extends PBGenerator {
+  PBBackArrowGenerator() : super();
+
+  @override
+  String generate(PBIntermediateNode source) {
+    if (source is InjectedBackArrow) {
+      return 'BackButton()';
+    }
+  }
+}


### PR DESCRIPTION
Closes #61

Adds an Egg that renders `.*back-arrow` as the Flutter [BackButton](https://api.flutter.dev/flutter/material/BackButton-class.html) widget, which is essentially an `IconButton` with the `back` icon of the target platform (Android, iOS) that returns to the previous route on click (using [Navigator.maybePop](https://api.flutter.dev/flutter/widgets/Navigator/maybePop.html)).

Example Sketch usage:
![image](https://user-images.githubusercontent.com/17351764/97782250-6fa00080-1bcb-11eb-9332-ebd772612108.png)

On Android this is rendered as:
![image](https://user-images.githubusercontent.com/17351764/97782377-28fed600-1bcc-11eb-910c-5293a0d3d27d.png)

You can use this Sketch file to test the behavior (sorry if its hideous, its a very minimal example):
[back_arrow.sketch.zip](https://github.com/Parabeac/Parabeac-Core/files/5469276/back_arrow.sketch.zip)

I wasn't sure if I should open the PR here or in [parabeac_eggs](https://github.com/Parabeac/parabeac_eggs), because the Eggs in [parabeac_eggs](https://github.com/Parabeac/parabeac_eggs) are no longer up to date, and won't run with the `dev`/`stable` branch (and even the `v1.2.0` tag) of `Parabeac-Core`.