### PR TITLE
Fixed an issue where nodes that contain prototyping use point values …

### DIFF
--- a/lib/generation/prototyping/pb_prototype_gen.dart
+++ b/lib/generation/prototyping/pb_prototype_gen.dart
@@ -23,7 +23,7 @@ class PBPrototypeGenerator extends PBGenerator {
           MaterialPageRoute(builder: (context) => ${name}()),
         );
       },
-      child: ${manager.generate(source.child, type: BUILDER_TYPE.BODY)},
+      child: ${manager.generate(source.child, type: source.builder_type ?? BUILDER_TYPE.BODY)},
       )''';
     } else {
       return manager.generate(source.child);


### PR DESCRIPTION
…instead of MediaQuery values.

Fixed #169 