### PR TITLE
Ignore objects that are set "No visible"

### DIFF
--- a/lib/interpret_and_optimize/services/pb_visual_generation_service.dart
+++ b/lib/interpret_and_optimize/services/pb_visual_generation_service.dart
@@ -118,7 +118,9 @@ class PBVisualGenerationService implements PBGenerationService {
       destHolder.addChild(rootIntermediateNode);
       return destHolder;
     }
-    _extractScreenSize(rootIntermediateNode);
+    if (rootIntermediateNode != null) {
+      _extractScreenSize(rootIntermediateNode);
+    }
     return rootIntermediateNode;
   }
 


### PR DESCRIPTION
The issue was that when an object is set as "No visible" it should not be processed, but it was trying to get screen size either way. Now, if it has "No visible" as true, it should be completely ignored