### PR TITLE
Added way to not process null rootNodes

### DIFF
--- a/lib/controllers/interpret.dart
+++ b/lib/controllers/interpret.dart
@@ -112,6 +112,10 @@ class Interpret {
     intermediateTree.rootNode = await visualGenerationService(
         parentComponent, currentContext, stopwatch);
 
+    if (intermediateTree.rootNode == null) {
+      return intermediateTree;
+    }
+
     ///
     /// pre-layout generation service for plugin nodes.
     /// NOTE Disabled Plugin Control Service for right now


### PR DESCRIPTION
The "Non-existent tree" warning was given because some of the rootNodes we were trying to process in the interpretation service were null. This was happening because they were state management nodes, meaning they were being removed from the tree when detected. To fix this, I added a simple if-statement during interpretation phase, after the visual generation service. This way, we do nut run all services if we have a null rootNode, which will save us incorrect warning/errors and also save time.