### PR TITLE
Fix/middleware imports

### DIFF
--- a/lib/generation/generators/middleware/middleware.dart
+++ b/lib/generation/generators/middleware/middleware.dart
@@ -1,5 +1,6 @@
 import 'package:parabeac_core/generation/generators/pb_generation_manager.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/subclasses/pb_intermediate_node.dart';
+import 'package:parabeac_core/interpret_and_optimize/helpers/pb_gen_cache.dart';
 import 'package:recase/recase.dart';
 
 abstract class Middleware {
@@ -19,4 +20,8 @@ abstract class Middleware {
 
   Future<PBIntermediateNode> applyMiddleware(PBIntermediateNode node) =>
       Future.value(node);
+
+  void addImportToCache(String id, String path) {
+    PBGenCache().addToCache(id, path);
+  }
 }

--- a/lib/generation/generators/middleware/state_management/provider_middleware.dart
+++ b/lib/generation/generators/middleware/state_management/provider_middleware.dart
@@ -5,6 +5,7 @@ import 'package:parabeac_core/generation/generators/pb_variable.dart';
 import 'package:parabeac_core/generation/generators/value_objects/file_structure_strategy.dart/provider_file_structure_strategy.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/pb_shared_instance.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/pb_shared_master_node.dart';
+import 'package:parabeac_core/interpret_and_optimize/helpers/pb_symbol_storage.dart';
 import 'package:recase/recase.dart';
 import 'package:parabeac_core/generation/generators/value_objects/generator_adapter.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/subclasses/pb_intermediate_node.dart';
@@ -31,8 +32,9 @@ class ProviderMiddleware extends Middleware {
       var watcher = PBVariable(watcherName, 'final ', true,
           'context.watch<${getName(node.functionCallName).pascalCase}>().defaultWidget');
       managerData.addMethodVariable(watcher);
-      await managerData.replaceImport(
-          watcherName, 'models/${getName(node.name).snakeCase}.dart');
+
+      addImportToCache(node.SYMBOL_ID, getImportPath(node, fileStrategy));
+
       node.generator = StringGeneratorAdapter(watcherName);
       return node;
     }
@@ -77,5 +79,13 @@ class ProviderMiddleware extends Middleware {
         node?.generator?.generate(node ?? '',
             GeneratorContext(sizingContext: SizingValueContext.PointValue)) +
         ';';
+  }
+
+  String getImportPath(PBSharedInstanceIntermediateNode node, fileStrategy) {
+    var symbolMaster =
+        PBSymbolStorage().getSharedMasterNodeBySymbolID(node.SYMBOL_ID);
+    return fileStrategy.GENERATED_PROJECT_PATH +
+        fileStrategy.RELATIVE_MODEL_PATH +
+        '${getName(symbolMaster.name).snakeCase}.dart';
   }
 }

--- a/lib/generation/generators/middleware/state_management/riverpod_middleware.dart
+++ b/lib/generation/generators/middleware/state_management/riverpod_middleware.dart
@@ -3,6 +3,7 @@ import 'package:parabeac_core/generation/generators/value_objects/file_structure
 import 'package:parabeac_core/generation/generators/value_objects/generator_adapter.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/pb_shared_instance.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/subclasses/pb_intermediate_node.dart';
+import 'package:parabeac_core/interpret_and_optimize/helpers/pb_symbol_storage.dart';
 import '../../pb_generation_manager.dart';
 import '../../pb_variable.dart';
 import '../middleware.dart';
@@ -31,8 +32,9 @@ class RiverpodMiddleware extends Middleware {
           'ChangeNotifierProvider((ref) => ${getName(node.functionCallName).pascalCase}())');
 
       managerData.addMethodVariable(watcher);
-      await managerData.replaceImport(
-          watcherName, 'models/${watcherName}.dart');
+
+      addImportToCache(node.SYMBOL_ID, getImportPath(node, fileStrategy));
+
       node.generator = StringGeneratorAdapter(getConsumer(watcherName));
       return node;
     }
@@ -85,5 +87,13 @@ class RiverpodMiddleware extends Middleware {
       },
     )
     ''';
+  }
+
+  String getImportPath(PBSharedInstanceIntermediateNode node, fileStrategy) {
+    var symbolMaster =
+        PBSymbolStorage().getSharedMasterNodeBySymbolID(node.SYMBOL_ID);
+    return fileStrategy.GENERATED_PROJECT_PATH +
+        fileStrategy.RELATIVE_MODEL_PATH +
+        '${getName(symbolMaster.name).snakeCase}.dart';
   }
 }

--- a/lib/generation/generators/middleware/state_management/stateful_middleware.dart
+++ b/lib/generation/generators/middleware/state_management/stateful_middleware.dart
@@ -23,10 +23,11 @@ class StatefulMiddleware extends Middleware {
     if (node is PBSharedInstanceIntermediateNode) {
       managerData.addAllMethodVariable(await _getVariables(node));
       node.generator = StringGeneratorAdapter(await _generateInstance(node));
+      addImportToCache(node.SYMBOL_ID, getImportPath(node, fileStrategy));
       return node;
     }
     var states = <PBIntermediateNode>[node];
-    var parentDirectory = node.name.snakeCase;
+    var parentDirectory = getName(node.name).snakeCase;
 
     await node?.auxiliaryData?.stateGraph?.states?.forEach((state) {
       states.add(state.variation.node);
@@ -73,5 +74,13 @@ class StatefulMiddleware extends Middleware {
 
   String _generateInstance(PBSharedInstanceIntermediateNode node) {
     return node.functionCallName.snakeCase;
+  }
+
+  String getImportPath(PBSharedInstanceIntermediateNode node, fileStrategy) {
+    var symbolMaster =
+        PBSymbolStorage().getSharedMasterNodeBySymbolID(node.SYMBOL_ID);
+    return fileStrategy.GENERATED_PROJECT_PATH +
+        fileStrategy.RELATIVE_VIEW_PATH +
+        '${getName(symbolMaster.name).snakeCase}/${node.functionCallName.snakeCase}.dart';
   }
 }

--- a/lib/generation/generators/util/pb_generation_view_data.dart
+++ b/lib/generation/generators/util/pb_generation_view_data.dart
@@ -87,44 +87,4 @@ class PBGenerationViewData {
       _methodVariables.addAll(variables);
     }
   }
-
-  Future<String> removeImportThatContains(String pattern) async {
-    for (var import in _imports) {
-      if (import is String && import.contains(pattern)) {
-        _imports.remove(import);
-        return import;
-      }
-    }
-    return '';
-  }
-
-  Future<void> replaceImport(String oldImport, String newImport) async {
-    if (!_isDataLocked) {
-      var oldVersion = await removeImportThatContains(oldImport);
-      if (oldVersion == '') {
-        return null;
-      }
-      var tempList = oldVersion.split('/');
-      tempList.removeLast();
-      tempList.add(newImport);
-      var tempList2 = tempList;
-      _imports.add(await _makeImport(tempList2));
-    }
-  }
-
-  Future<String> _makeImport(List<String> tempList) async {
-    var tempString = tempList.removeAt(0);
-    for (var item in tempList) {
-      if (item == 'view') {
-        var tempLast = tempList.removeLast();
-        if (!tempLast.contains('models')) {
-          tempString += '/${item}';
-        }
-        tempString += '/${tempLast}';
-        break;
-      }
-      tempString += '/${item}';
-    }
-    return tempString;
-  }
 }

--- a/lib/generation/generators/value_objects/generation_configuration/pb_generation_configuration.dart
+++ b/lib/generation/generators/value_objects/generation_configuration/pb_generation_configuration.dart
@@ -112,9 +112,9 @@ abstract class GenerationConfiguration {
         await _setMainScreen(
             tree.rootNode, '${tree.name.snakeCase}/${fileName}.dart');
       }
-      _commitImports(tree.rootNode, tree.name.snakeCase, fileName);
-
       await _iterateNode(tree.rootNode);
+
+      await _commitImports(tree.rootNode, tree.name.snakeCase, fileName);
 
       await _generateNode(tree.rootNode, '${tree.name.snakeCase}/${fileName}');
     }
@@ -135,8 +135,8 @@ abstract class GenerationConfiguration {
     await fileStructureStrategy.setUpDirectories();
   }
 
-  void _commitImports(
-      PBIntermediateNode node, String directoryName, String fileName) {
+  Future<void> _commitImports(
+      PBIntermediateNode node, String directoryName, String fileName) async {
     var screenFilePath =
         '${pbProject.projectName}/lib/screens/${directoryName}/${fileName.snakeCase}.dart';
     var viewFilePath =

--- a/lib/generation/generators/value_objects/generation_configuration/pb_generation_configuration.dart
+++ b/lib/generation/generators/value_objects/generation_configuration/pb_generation_configuration.dart
@@ -114,7 +114,7 @@ abstract class GenerationConfiguration {
       }
       await _iterateNode(tree.rootNode);
 
-      await _commitImports(tree.rootNode, tree.name.snakeCase, fileName);
+      _commitImports(tree.rootNode, tree.name.snakeCase, fileName);
 
       await _generateNode(tree.rootNode, '${tree.name.snakeCase}/${fileName}');
     }
@@ -135,8 +135,8 @@ abstract class GenerationConfiguration {
     await fileStructureStrategy.setUpDirectories();
   }
 
-  Future<void> _commitImports(
-      PBIntermediateNode node, String directoryName, String fileName) async {
+  void _commitImports(
+      PBIntermediateNode node, String directoryName, String fileName) {
     var screenFilePath =
         '${pbProject.projectName}/lib/screens/${directoryName}/${fileName.snakeCase}.dart';
     var viewFilePath =


### PR DESCRIPTION
- Middlewares now uses PBGenCache to store import relationships 
- The above applies to Stateful, Provider, BLoC & Riverpod
- Unused methods were removed