### PR TITLE
Fix/imports

### DIFF
--- a/lib/generation/generators/value_objects/generation_configuration/pb_generation_configuration.dart
+++ b/lib/generation/generators/value_objects/generation_configuration/pb_generation_configuration.dart
@@ -12,6 +12,7 @@ import 'package:parabeac_core/interpret_and_optimize/entities/pb_shared_instance
 import 'package:parabeac_core/interpret_and_optimize/entities/subclasses/pb_intermediate_node.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/subclasses/pb_layout_intermediate_node.dart';
 import 'package:parabeac_core/generation/generators/pb_flutter_generator.dart';
+import 'package:parabeac_core/interpret_and_optimize/helpers/pb_gen_cache.dart';
 import 'package:parabeac_core/interpret_and_optimize/helpers/pb_symbol_storage.dart';
 import 'package:parabeac_core/interpret_and_optimize/helpers/pb_project.dart';
 import 'package:quick_log/quick_log.dart';
@@ -138,12 +139,8 @@ abstract class GenerationConfiguration {
 
   void _commitImports(
       PBIntermediateNode node, String directoryName, String fileName) {
-    var screenFilePath =
-        '${pbProject.projectName}/lib/screens/${directoryName}/${fileName.snakeCase}.dart';
-    var viewFilePath =
-        '${pbProject.projectName}/lib/view/${directoryName}/${fileName.snakeCase}.dart'; // Removed .g
-    var imports = ImportHelper.findImports(
-        node, node is InheritedScaffold ? screenFilePath : viewFilePath);
+    var nodePath = PBGenCache().getPath(node.UUID);
+    var imports = ImportHelper.findImports(node, nodePath);
     imports.forEach((import) {
       node.managerData.addImport(import);
     });

--- a/lib/generation/generators/value_objects/generation_configuration/pb_generation_configuration.dart
+++ b/lib/generation/generators/value_objects/generation_configuration/pb_generation_configuration.dart
@@ -9,6 +9,7 @@ import 'package:parabeac_core/interpret_and_optimize/entities/inherited_scaffold
 import 'package:parabeac_core/generation/generators/value_objects/file_structure_strategy.dart/flutter_file_structure_strategy.dart';
 import 'package:parabeac_core/generation/generators/value_objects/file_structure_strategy.dart/pb_file_structure_strategy.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/pb_shared_instance.dart';
+import 'package:parabeac_core/interpret_and_optimize/entities/pb_shared_master_node.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/subclasses/pb_intermediate_node.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/subclasses/pb_layout_intermediate_node.dart';
 import 'package:parabeac_core/generation/generators/pb_flutter_generator.dart';
@@ -139,7 +140,8 @@ abstract class GenerationConfiguration {
 
   void _commitImports(
       PBIntermediateNode node, String directoryName, String fileName) {
-    var nodePath = PBGenCache().getPath(node.UUID);
+    var nodePath = PBGenCache()
+        .getPath(node is PBSharedMasterNode ? node.SYMBOL_ID : node.UUID);
     var imports = ImportHelper.findImports(node, nodePath);
     imports.forEach((import) {
       node.managerData.addImport(import);

--- a/lib/generation/generators/value_objects/generation_configuration/pb_generation_configuration.dart
+++ b/lib/generation/generators/value_objects/generation_configuration/pb_generation_configuration.dart
@@ -141,7 +141,7 @@ abstract class GenerationConfiguration {
     var screenFilePath =
         '${pbProject.projectName}/lib/screens/${directoryName}/${fileName.snakeCase}.dart';
     var viewFilePath =
-        '${pbProject.projectName}/lib/views/${directoryName}/${fileName.snakeCase}.dart'; // Removed .g
+        '${pbProject.projectName}/lib/view/${directoryName}/${fileName.snakeCase}.dart'; // Removed .g
     var imports = ImportHelper.findImports(
         node, node is InheritedScaffold ? screenFilePath : viewFilePath);
     imports.forEach((import) {


### PR DESCRIPTION
* Using PBGenCache to generate a node's path instead of hardcoding the path. This allows us to properly detect whether a node is a model, screen, symbol, etc.