### PR TITLE
FIX breaking changes dealing with logging an error during image processing.

### DIFF
--- a/lib/input/sketch/helper/sketch_asset_processor.dart
+++ b/lib/input/sketch/helper/sketch_asset_processor.dart
@@ -57,11 +57,11 @@ class SketchAssetProcessor extends AssetProcessingService {
       }
       return response?.bodyBytes;
     } catch (e) {
-      var imageErr =
-          File('${MainInfo().cwd.path}/lib/input/assets/image-conversion-error.png')
-              .readAsBytesSync();
+      var imageErr = File(
+              '${MainInfo().cwd.path}/lib/input/assets/image-conversion-error.png')
+          .readAsBytesSync();
       await MainInfo().sentry.captureException(exception: e);
-      log.error(e.message);
+      log.error(e.toString());
       return imageErr;
     }
   }


### PR DESCRIPTION
When an error was caught during the image generation, we tried printing the message of the error. However, the error does not contain the field for the message, causing a _NoSuchMethod Exception_ in the logging of the error. 