### PR TITLE
Fix/global var symbols

### DIFF
--- a/lib/generation/generators/attribute-helper/pb_generator_context.dart
+++ b/lib/generation/generators/attribute-helper/pb_generator_context.dart
@@ -1,11 +1,10 @@
-import 'package:parabeac_core/interpret_and_optimize/entities/pb_shared_master_node.dart';
-
 /// This class is responsible for sharing contextual data needed throughout the generation process. Generators will pass this information to it's children.
 class GeneratorContext {
   SizingValueContext sizingContext = SizingValueContext.PointValue;
-  List<PBSharedParameterProp> overridableProperties = [];
 
-  GeneratorContext({this.sizingContext, this.overridableProperties});
+  GeneratorContext({
+    this.sizingContext,
+  });
 }
 
 enum SizingValueContext {

--- a/lib/generation/generators/attribute-helper/pb_generator_context.dart
+++ b/lib/generation/generators/attribute-helper/pb_generator_context.dart
@@ -1,7 +1,11 @@
+import 'package:parabeac_core/interpret_and_optimize/entities/pb_shared_master_node.dart';
+
 /// This class is responsible for sharing contextual data needed throughout the generation process. Generators will pass this information to it's children.
 class GeneratorContext {
-  GeneratorContext({this.sizingContext});
   SizingValueContext sizingContext = SizingValueContext.PointValue;
+  List<PBSharedParameterProp> overridableProperties = [];
+
+  GeneratorContext({this.sizingContext, this.overridableProperties});
 }
 
 enum SizingValueContext {

--- a/lib/generation/generators/middleware/state_management/stateful_middleware.dart
+++ b/lib/generation/generators/middleware/state_management/stateful_middleware.dart
@@ -1,14 +1,10 @@
 import 'package:parabeac_core/generation/generators/middleware/middleware.dart';
-import 'package:parabeac_core/generation/generators/middleware/state_management/utils/middleware_utils.dart';
 import 'package:parabeac_core/generation/generators/pb_generation_manager.dart';
 import 'package:parabeac_core/generation/generators/value_objects/file_structure_strategy.dart/flutter_file_structure_strategy.dart';
-import 'package:parabeac_core/generation/generators/value_objects/generator_adapter.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/pb_shared_instance.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/subclasses/pb_intermediate_node.dart';
 import 'package:parabeac_core/interpret_and_optimize/helpers/pb_symbol_storage.dart';
 import 'package:recase/recase.dart';
-
-import '../../pb_variable.dart';
 
 class StatefulMiddleware extends Middleware {
   StatefulMiddleware(PBGenerationManager generationManager)
@@ -16,15 +12,10 @@ class StatefulMiddleware extends Middleware {
 
   @override
   Future<PBIntermediateNode> applyMiddleware(PBIntermediateNode node) async {
-    var managerData = node.managerData;
     var fileStrategy = node.currentContext.project.fileStructureStrategy
         as FlutterFileStructureStrategy;
 
     if (node is PBSharedInstanceIntermediateNode) {
-      managerData.addGlobalVariable(await _getVariables(node));
-      if (node.generator is! StringGeneratorAdapter) {
-        node.generator = StringGeneratorAdapter(node.name.snakeCase);
-      }
       addImportToCache(node.SYMBOL_ID, getImportPath(node, fileStrategy));
       return node;
     }
@@ -45,25 +36,6 @@ class StatefulMiddleware extends Middleware {
     });
 
     return node;
-  }
-
-  Future<PBVariable> _getVariables(
-      PBSharedInstanceIntermediateNode node) async {
-    var symbolMaster =
-        PBSymbolStorage().getSharedMasterNodeBySymbolID(node.SYMBOL_ID);
-
-    var watcherName = getVariableName(node.name.snakeCase);
-
-    var tempVar = PBVariable(
-      watcherName,
-      'var ',
-      true,
-      node.functionCallName == symbolMaster.name
-          ? MiddlewareUtils.wrapOnLayout('${symbolMaster.name.pascalCase}')
-          : null,
-    );
-
-    return tempVar;
   }
 
   String getImportPath(PBSharedInstanceIntermediateNode node, fileStrategy) {

--- a/lib/generation/generators/symbols/pb_instancesym_gen.dart
+++ b/lib/generation/generators/symbols/pb_instancesym_gen.dart
@@ -27,15 +27,27 @@ class PBSymbolInstanceGenerator extends PBGenerator {
         log.error(' Could not find master name on: $source');
         return 'Container(/** This Symbol was not found **/)';
       }
+
+      var overrideProp = generatorContext?.overridableProperties?.firstWhere(
+          (element) => element.UUID == source.UUID,
+          orElse: () => null);
+
       method_signature = PBInputFormatter.formatLabel(method_signature,
           destroy_digits: false, space_to_underscore: false, isTitle: false);
       var buffer = StringBuffer();
+
       buffer.write('LayoutBuilder( \n');
       buffer.write('  builder: (context, constraints) {\n');
       buffer.write('    return ');
+
+      if (overrideProp != null) {
+        buffer.write('${overrideProp.friendlyName} ?? ');
+      }
+
       buffer.write(method_signature);
       buffer.write('(');
       buffer.write('constraints,');
+
       for (var param in source.sharedParamValues ?? []) {
         switch (param.type) {
           case PBSharedInstanceIntermediateNode:

--- a/lib/generation/generators/symbols/pb_instancesym_gen.dart
+++ b/lib/generation/generators/symbols/pb_instancesym_gen.dart
@@ -28,9 +28,7 @@ class PBSymbolInstanceGenerator extends PBGenerator {
         return 'Container(/** This Symbol was not found **/)';
       }
 
-      var overrideProp = generatorContext?.overridableProperties?.firstWhere(
-          (element) => element.UUID == source.UUID,
-          orElse: () => null);
+      var overrideProp = SN_UUIDtoVarName[source.UUID + '_symbolID'];
 
       method_signature = PBInputFormatter.formatLabel(method_signature,
           destroy_digits: false, space_to_underscore: false, isTitle: false);
@@ -41,7 +39,7 @@ class PBSymbolInstanceGenerator extends PBGenerator {
       buffer.write('    return ');
 
       if (overrideProp != null) {
-        buffer.write('${overrideProp.friendlyName} ?? ');
+        buffer.write('${overrideProp} ?? ');
       }
 
       buffer.write(method_signature);

--- a/lib/generation/generators/symbols/pb_instancesym_gen.dart
+++ b/lib/generation/generators/symbols/pb_instancesym_gen.dart
@@ -19,17 +19,16 @@ class PBSymbolInstanceGenerator extends PBGenerator {
   var log = Logger('Symbol Instance Generator');
 
   @override
-  String generate(PBIntermediateNode source,
-      GeneratorContext generatorContext) {
+  String generate(
+      PBIntermediateNode source, GeneratorContext generatorContext) {
     if (source is PBSharedInstanceIntermediateNode) {
-      var method_signature = source.functionCallName;
+      var method_signature = source.functionCallName.pascalCase;
       if (method_signature == null) {
         log.error(' Could not find master name on: $source');
         return 'Container(/** This Symbol was not found **/)';
       }
       method_signature = PBInputFormatter.formatLabel(method_signature,
           destroy_digits: false, space_to_underscore: false, isTitle: false);
-      method_signature = method_signature.pascalCase;
       var buffer = StringBuffer();
       buffer.write('LayoutBuilder( \n');
       buffer.write('  builder: (context, constraints) {\n');
@@ -41,19 +40,18 @@ class PBSymbolInstanceGenerator extends PBGenerator {
         switch (param.type) {
           case PBSharedInstanceIntermediateNode:
             buffer.write('${param.name}: ');
-            buffer.write(genSymbolInstance(param.UUID, param.value, source.overrideValues));
+            buffer.write(genSymbolInstance(
+                param.UUID, param.value, source.overrideValues));
             break;
           case InheritedBitmap:
             buffer.write('${param.name}: \"assets/${param.value["_ref"]}\",');
             break;
           case TextStyle:
-          // hack to include import
+            // hack to include import
             source.generator.manager.data.addImport(
-                'package:${MainInfo()
-                    .projectName}/document/shared_props.g.dart');
+                'package:${MainInfo().projectName}/document/shared_props.g.dart');
             buffer.write(
-                '${param.name}: ${SharedStyle_UUIDToName[param.value] ??
-                    "TextStyle()"},');
+                '${param.name}: ${SharedStyle_UUIDToName[param.value] ?? "TextStyle()"},');
             break;
           default:
             buffer.write('${param.name}: \"${param.value}\",');
@@ -68,24 +66,27 @@ class PBSymbolInstanceGenerator extends PBGenerator {
       buffer.write(')');
       return buffer.toString();
     }
+    return '';
   }
 
   String genSymbolInstance(String overrideUUID, String UUID,
       List<PBSymbolInstanceOverridableValue> overrideValues,
-      { int depth = 1 }) {
+      {int depth = 1}) {
     var masterSymbol = PBSymbolStorage().getSharedMasterNodeBySymbolID(UUID);
-    assert(masterSymbol !=
-        null, 'Could not find master symbol with UUID: ${UUID}');
+    assert(masterSymbol != null,
+        'Could not find master symbol with UUID: ${UUID}');
     var buffer = StringBuffer();
     buffer.write('${masterSymbol.friendlyName}(constraints, ');
     for (var ovrValue in overrideValues) {
       var ovrUUIDStrings = ovrValue.UUID.split('/');
-      if ((ovrUUIDStrings.length == depth + 1) && (ovrUUIDStrings[depth-1] == overrideUUID)) {
+      if ((ovrUUIDStrings.length == depth + 1) &&
+          (ovrUUIDStrings[depth - 1] == overrideUUID)) {
         var ovrUUID = ovrUUIDStrings[depth];
         switch (ovrValue.type) {
           case PBSharedInstanceIntermediateNode:
-            buffer.write(
-                genSymbolInstance(ovrValue.value, ovrUUID, overrideValues, depth: depth + 1));
+            buffer.write(genSymbolInstance(
+                ovrValue.value, ovrUUID, overrideValues,
+                depth: depth + 1));
             break;
           case InheritedBitmap:
             var name = SN_UUIDtoVarName[ovrUUID + '_image'];
@@ -93,8 +94,8 @@ class PBSymbolInstanceGenerator extends PBGenerator {
             break;
           case TextStyle:
             var name = SN_UUIDtoVarName[ovrUUID + '_textStyle'];
-            buffer.write('${name}: ${SharedStyle_UUIDToName[ovrValue.value] ??
-                "TextStyle()"},');
+            buffer.write(
+                '${name}: ${SharedStyle_UUIDToName[ovrValue.value] ?? "TextStyle()"},');
             break;
           default:
             var name = SN_UUIDtoVarName[ovrUUID];

--- a/lib/generation/generators/symbols/pb_mastersym_gen.dart
+++ b/lib/generation/generators/symbols/pb_mastersym_gen.dart
@@ -16,6 +16,8 @@ class PBMasterSymbolGenerator extends PBGenerator {
     generatorContext.sizingContext = SizingValueContext.LayoutBuilderValue;
     var buffer = StringBuffer();
     if (source is PBSharedMasterNode) {
+      generatorContext.overridableProperties =
+          source.overridableProperties ?? [];
       if (source.child == null) {
         return '';
       }
@@ -23,6 +25,7 @@ class PBMasterSymbolGenerator extends PBGenerator {
       // see if widget itself is overridden, need to pass
       var generatedWidget =
           source.child.generator.generate(source.child, generatorContext);
+
       if (generatedWidget == null || generatedWidget.isEmpty) {
         return '';
       }

--- a/lib/generation/generators/symbols/pb_mastersym_gen.dart
+++ b/lib/generation/generators/symbols/pb_mastersym_gen.dart
@@ -15,8 +15,6 @@ class PBMasterSymbolGenerator extends PBGenerator {
     generatorContext.sizingContext = SizingValueContext.LayoutBuilderValue;
     var buffer = StringBuffer();
     if (source is PBSharedMasterNode) {
-      generatorContext.overridableProperties =
-          source.overridableProperties ?? [];
       if (source.child == null) {
         return '';
       }

--- a/lib/generation/generators/symbols/pb_mastersym_gen.dart
+++ b/lib/generation/generators/symbols/pb_mastersym_gen.dart
@@ -1,4 +1,3 @@
-import 'package:parabeac_core/controllers/main_info.dart';
 import 'package:parabeac_core/generation/generators/attribute-helper/pb_generator_context.dart';
 import 'package:parabeac_core/generation/generators/pb_generator.dart';
 import 'package:parabeac_core/generation/generators/value_objects/template_strategy/stateless_template_strategy.dart';

--- a/lib/generation/generators/visual-widgets/pb_bitmap_gen.dart
+++ b/lib/generation/generators/visual-widgets/pb_bitmap_gen.dart
@@ -17,15 +17,10 @@ class PBBitmapGenerator extends PBGenerator {
   String generate(
       PBIntermediateNode source, GeneratorContext generatorContext) {
     var buffer = StringBuffer();
-    var overrideProp = generatorContext?.overridableProperties?.firstWhere(
-        (element) => element.UUID == source.UUID,
-        orElse: () => null);
 
     buffer.write('Image.asset(');
     if (SN_UUIDtoVarName.containsKey('${source.UUID}_image')) {
       buffer.write('${SN_UUIDtoVarName[source.UUID + '_image']} ?? ');
-    } else if (overrideProp != null) {
-      buffer.write('${overrideProp.friendlyName} ?? ');
     }
     buffer.write(
         '\'assets/${source is InheritedBitmap ? source.referenceImage : ('images/' + source.UUID + '.png')}\', ${_sizehelper.generate(source, generatorContext)})');

--- a/lib/generation/generators/visual-widgets/pb_bitmap_gen.dart
+++ b/lib/generation/generators/visual-widgets/pb_bitmap_gen.dart
@@ -21,6 +21,8 @@ class PBBitmapGenerator extends PBGenerator {
     buffer.write('Image.asset(');
     if (SN_UUIDtoVarName.containsKey('${source.UUID}_image')) {
       buffer.write('${SN_UUIDtoVarName[source.UUID + '_image']} ?? ');
+    } else if (SN_UUIDtoVarName.containsKey('${source.UUID}_layerStyle')) {
+      buffer.write('${SN_UUIDtoVarName[source.UUID + '_layerStyle']} ?? ');
     }
     buffer.write(
         '\'assets/${source is InheritedBitmap ? source.referenceImage : ('images/' + source.UUID + '.png')}\', ${_sizehelper.generate(source, generatorContext)})');

--- a/lib/generation/generators/visual-widgets/pb_bitmap_gen.dart
+++ b/lib/generation/generators/visual-widgets/pb_bitmap_gen.dart
@@ -17,9 +17,15 @@ class PBBitmapGenerator extends PBGenerator {
   String generate(
       PBIntermediateNode source, GeneratorContext generatorContext) {
     var buffer = StringBuffer();
+    var overrideProp = generatorContext?.overridableProperties?.firstWhere(
+        (element) => element.UUID == source.UUID,
+        orElse: () => null);
+
     buffer.write('Image.asset(');
     if (SN_UUIDtoVarName.containsKey('${source.UUID}_image')) {
       buffer.write('${SN_UUIDtoVarName[source.UUID + '_image']} ?? ');
+    } else if (overrideProp != null) {
+      buffer.write('${overrideProp.friendlyName} ?? ');
     }
     buffer.write(
         '\'assets/${source is InheritedBitmap ? source.referenceImage : ('images/' + source.UUID + '.png')}\', ${_sizehelper.generate(source, generatorContext)})');


### PR DESCRIPTION
* Symbols no longer generate global variables. Instead, these are generated within the build() method.
* Add overridableproperties to symbol masters