### PR TITLE
Store platform and orientation on PBIntermediateTree

### DIFF
--- a/lib/controllers/controller.dart
+++ b/lib/controllers/controller.dart
@@ -36,8 +36,6 @@ abstract class Controller {
 
     var pbProject = await Interpret().interpretAndOptimize(designProject);
 
-    pbProject.forest.forEach((tree) => tree.data = PBGenerationViewData());
-
     await PreGenerationService(
       projectName: projectPath,
       mainTree: pbProject,

--- a/lib/controllers/interpret.dart
+++ b/lib/controllers/interpret.dart
@@ -1,4 +1,6 @@
 import 'package:parabeac_core/controllers/main_info.dart';
+import 'package:parabeac_core/controllers/utils/interpret_utils.dart';
+import 'package:parabeac_core/generation/generators/util/pb_generation_view_data.dart';
 import 'package:parabeac_core/generation/prototyping/pb_prototype_linker_service.dart';
 import 'package:parabeac_core/input/helper/design_project.dart';
 import 'package:parabeac_core/input/helper/design_page.dart';
@@ -20,7 +22,7 @@ import 'package:quick_log/quick_log.dart';
 
 import 'main_info.dart';
 
-class Interpret {
+class Interpret with InterpretUtils {
   var log = Logger('Interpret');
 
   Interpret._internal();
@@ -77,8 +79,13 @@ class Interpret {
         var tempTree = currentScreen;
         tempTree.name = designPage.name;
 
+        tempTree.data = PBGenerationViewData();
         if (currentScreen.rootNode is InheritedScaffold) {
-          tempTree.tree_type = TREE_TYPE.SCREEN;
+          tempTree.data.platform = extractPlatform(designPage.name);
+
+          tempTree.data.orientation = extractOrientation(
+              tempTree.rootNode.bottomRightCorner,
+              tempTree.rootNode.topLeftCorner);
         } else if (currentScreen.rootNode is PBSharedMasterNode) {
           tempTree.tree_type = TREE_TYPE.VIEW;
         } else {

--- a/lib/controllers/utils/interpret_utils.dart
+++ b/lib/controllers/utils/interpret_utils.dart
@@ -1,0 +1,32 @@
+import 'package:parabeac_core/generation/generators/util/pb_generation_view_data.dart';
+import 'package:parabeac_core/interpret_and_optimize/value_objects/point.dart';
+
+/// Utils that extract platform and orientation from a node.
+mixin InterpretUtils {
+  /// Extracts and returns platform of the screen.
+  ///
+  /// Defaults to PLATFORM.MOBILE if no platform is given.
+  PLATFORM extractPlatform(String name) {
+    var platform = name?.split('/')?.last?.toLowerCase()?.trim() ?? '';
+    switch (platform) {
+      case 'desktop':
+        return PLATFORM.DESKTOP;
+      case 'tablet':
+        return PLATFORM.TABLET;
+      default:
+        return PLATFORM.MOBILE;
+    }
+  }
+
+  /// Extracts orientation based on a node's TLC and BRC points.
+  ORIENTATION extractOrientation(Point bottomRight, Point topLeft) {
+    var width = (topLeft.x - bottomRight.x).abs();
+    var height = (topLeft.y - bottomRight.y).abs();
+
+    if (height < width) {
+      return ORIENTATION.HORIZONTAL;
+    }
+
+    return ORIENTATION.VERTICAL;
+  }
+}

--- a/lib/generation/generators/attribute-helper/pb_size_helper.dart
+++ b/lib/generation/generators/attribute-helper/pb_size_helper.dart
@@ -20,13 +20,19 @@ class PBSizeHelper extends PBAttributesHelper {
     var body = source.size ?? {};
     double height = body['height'];
     double width = body['width'];
+
     //Add relative sizing if the widget has context
-    var screenWidth = ((source.currentContext.screenTopLeftCorner.x) -
-            (source.currentContext.screenBottomRightCorner.x))
-        .abs();
-    var screenHeight = ((source.currentContext.screenTopLeftCorner.y) -
-            (source.currentContext.screenBottomRightCorner.y))
-        .abs();
+    var screenWidth;
+    var screenHeight;
+    if (source.currentContext.screenTopLeftCorner != null &&
+        source.currentContext.screenBottomRightCorner != null) {
+      screenWidth = ((source.currentContext.screenTopLeftCorner.x) -
+              (source.currentContext.screenBottomRightCorner.x))
+          .abs();
+      screenHeight = ((source.currentContext.screenTopLeftCorner.y) -
+              (source.currentContext.screenBottomRightCorner.y))
+          .abs();
+    }
 
     height = (height != null && screenHeight != null && screenHeight > 0.0)
         ? height / screenHeight

--- a/lib/generation/generators/util/pb_generation_view_data.dart
+++ b/lib/generation/generators/util/pb_generation_view_data.dart
@@ -9,6 +9,9 @@ class PBGenerationViewData {
   final Set<String> _toDispose = {};
   bool _isDataLocked = false;
 
+  PLATFORM platform;
+  ORIENTATION orientation;
+
   PBGenerationViewData();
 
   Iterator<String> get toDispose => _toDispose.iterator;
@@ -75,4 +78,15 @@ class PBGenerationViewData {
       _methodVariables[variable.variableName] = variable;
     }
   }
+}
+
+enum PLATFORM {
+  DESKTOP,
+  MOBILE,
+  TABLET,
+}
+
+enum ORIENTATION {
+  HORIZONTAL,
+  VERTICAL,
 }


### PR DESCRIPTION
Added mixins that extract platform and orientation data that is assigned to PBGenerationViewData.

Co-authored-by: Bryan Figueroa <SushiRoll53@users.noreply.github.com>