### PR TITLE
Replace dartfmt for dart format command

### DIFF
--- a/lib/generation/flutter_project_builder/flutter_project_builder.dart
+++ b/lib/generation/flutter_project_builder/flutter_project_builder.dart
@@ -154,9 +154,9 @@ class FlutterProjectBuilder {
 
     log.info(
       Process.runSync(
-              'dartfmt',
+              'dart',
               [
-                '-w',
+                'format',
                 '${pathToFlutterProject}bin',
                 '${pathToFlutterProject}lib',
                 '${pathToFlutterProject}test'


### PR DESCRIPTION
- dartfmt will (if not already) be deprecated from the DartSDK, so we will use `dart format` instead.

https://dart.dev/tools/dart-format