### PR TITLE
Bugfix/463 wrong png paths

### DIFF
--- a/lib/controllers/controller.dart
+++ b/lib/controllers/controller.dart
@@ -37,6 +37,7 @@ abstract class Controller {
     var fpb = FlutterProjectBuilder(
         MainInfo().configuration.generationConfiguration,
         project: pbProject,
+        genProjectAbsPath: configuration.genProjectPath,
         pageWriter: PBFlutterWriter());
 
     await fpb.convertToFlutterProject();

--- a/lib/controllers/controller.dart
+++ b/lib/controllers/controller.dart
@@ -4,44 +4,77 @@ import 'package:parabeac_core/generation/generators/writers/pb_flutter_writer.da
 import 'package:parabeac_core/input/helper/asset_processing_service.dart';
 import 'package:parabeac_core/input/helper/azure_asset_service.dart';
 import 'package:parabeac_core/input/helper/design_project.dart';
-import 'package:parabeac_core/interpret_and_optimize/helpers/pb_configuration.dart';
 import 'package:quick_log/quick_log.dart';
 import 'dart:convert';
 import 'dart:io';
+import 'package:meta/meta.dart';
 import 'main_info.dart';
+import 'package:path/path.dart' as p;
 
 abstract class Controller {
-  ///SERVICE
-  var log = Logger('Controller');
+  /// Represents an identifier for the current [Controller] at runtime.
+  ///
+  /// The main way of using this is to identify what [Controller] is going to be
+  /// used based on the [designType] within the `main.dart` file
+  DesignType get designType;
 
-  Controller();
+  var log;
 
-  void convertFile(
-    var fileAbsPath,
-    var projectPath,
-    PBConfiguration configuration, {
-    bool jsonOnly = false,
-    DesignProject designProject,
-    AssetProcessingService apService,
-  }) async {
+  Controller() {
+    log = Logger(runtimeType.toString());
+  }
+
+  /// Gathering all the necessary information for the [Controller] to function
+  /// properly
+  ///
+  /// Most, if not all, of the information will come from the [MainInfo] class.
+  Future<void> setup() {
+    var processInfo = MainInfo();
+
+    /// This is currently a workaround for PB-Nest. This
+    /// code usually was in the `main.dart`, however, I aggregated all
+    /// the calls in the default [setup] method for the [Controller]
+    if (processInfo.pbdlPath != null) {
+      var pbdl = File(processInfo.pbdlPath).readAsStringSync();
+      processInfo.pbdf = json.decode(pbdl);
+    }
+  }
+
+  @protected
+
+  /// Mainly used by the subclasses to convert the [designProject] to flutter code.
+  ///
+  /// There is a seperation of the methods because some of the [Controller]s need
+  /// to generate the [designProject] based on the parameters pased to
+  void convert(DesignProject designProject,
+      [AssetProcessingService apService]) async {
+    var processInfo = MainInfo();
+    var configuration = processInfo.configuration;
+
     /// IN CASE OF JSON ONLY
-    if (jsonOnly) {
+    if (processInfo.exportPBDL) {
       return stopAndToJson(designProject, apService);
     }
 
-    Interpret().init(projectPath, configuration);
+    var projectGenFuture = await FlutterProjectBuilder.createFlutterProject(
+        processInfo.projectName,
+        projectDir: processInfo.outputPath);
+
+    Interpret().init(processInfo.genProjectPath, configuration);
 
     var pbProject = await Interpret().interpretAndOptimize(
-        designProject, configuration.projectName, configuration.genProjectPath);
+        designProject, processInfo.projectName, processInfo.genProjectPath);
 
     var fpb = FlutterProjectBuilder(
         MainInfo().configuration.generationConfiguration,
         project: pbProject,
-        genProjectAbsPath: configuration.genProjectPath,
         pageWriter: PBFlutterWriter());
 
-    await fpb.convertToFlutterProject();
+    await fpb.genProjectFiles(projectGenFuture.item1);
   }
+
+  void convertFile(
+      {AssetProcessingService apService, DesignProject designProject});
 
   /// Method that returns the given path and ensures
   /// it ends with a /

--- a/lib/controllers/design_controller.dart
+++ b/lib/controllers/design_controller.dart
@@ -1,35 +1,27 @@
+import 'package:parabeac_core/controllers/main_info.dart';
 import 'package:parabeac_core/input/helper/asset_processing_service.dart';
 import 'package:parabeac_core/input/helper/azure_asset_service.dart';
 import 'package:parabeac_core/input/helper/design_project.dart';
-import 'package:quick_log/quick_log.dart';
 
 import 'controller.dart';
 
 class DesignController extends Controller {
   @override
-  var log = Logger('FigmaController');
-
-  DesignController();
+  DesignType get designType => DesignType.PBDL;
 
   @override
-  void convertFile(
-    var pbdf,
-    var outputPath,
-    configuration, {
-    bool jsonOnly = false,
+  void convertFile({
     DesignProject designProject,
     AssetProcessingService apService,
   }) async {
-    var designProject = generateDesignProject(pbdf, outputPath);
+    var pbdf = MainInfo().pbdf;
+    if (pbdf == null) {
+      throw Error(); //todo: throw correct error
+    }
+    designProject ??= generateDesignProject(pbdf, MainInfo().genProjectPath);
     AzureAssetService().projectUUID = pbdf['id'];
 
-    super.convertFile(
-      pbdf,
-      outputPath,
-      configuration,
-      designProject: designProject,
-      jsonOnly: jsonOnly,
-    );
+    super.convert(designProject, apService);
   }
 
   DesignProject generateDesignProject(var pbdf, var proejctName) {

--- a/lib/controllers/main_info.dart
+++ b/lib/controllers/main_info.dart
@@ -2,21 +2,56 @@ import 'dart:io';
 
 import 'package:parabeac_core/interpret_and_optimize/helpers/pb_configuration.dart';
 import 'package:sentry/sentry.dart';
+import 'package:path/path.dart' as p;
 
 class MainInfo {
   static final MainInfo _singleton = MainInfo._internal();
-  SentryClient sentry;
+  
+  final SentryClient _sentry = SentryClient(
+      dsn:
+          'https://6e011ce0d8cd4b7fb0ff284a23c5cb37@o433482.ingest.sentry.io/5388747');
 
-  /// Path representing where the output of parabeac-core will be produced
-  String outputPath;
+  @Deprecated('Use the function handle error for logging and capturing the error')
+  SentryClient get sentry => _sentry;
+
+  /// Path representing where the output of parabeac-core will be produced to.
+  /// 
+  /// First, we are going to check the if any path was passed as a flag to [outputPath], 
+  /// then check in the [configuration] to see if there are any paths saved ([PBConfiguration.outputDirPath]).
+  String _outputPath;
+  String get outputPath =>  _outputPath ?? configuration?.outputDirPath;
+  set outputPath(String path) => _outputPath = _validatePath(path);
 
   /// Path to the user's sketch file
-  String sketchPath;
+  String _designFilePath;
+  String get designFilePath => _designFilePath;
+  set designFilePath(String path) => _designFilePath = _validatePath(path);
+
+  /// Absolute path of where the flutter project is going to be generating at.
+  /// 
+  /// If its PBC is generating the flutter project, its going to [p.join] the 
+  /// [outputPath] and the [projectName]. Meaning the the code should be generated 
+  /// into the flutter directory. Otherwise, the code is going to be generated within the directory
+  /// specified in the [outputPath].
+  String get genProjectPath {
+    return p.join(outputPath, projectName ?? '');
+  }
 
   String platform;
 
   /// Current working directory; contains the path from where the script was called
   Directory cwd;
+
+  /// The path of where the PBDL file is at.
+  String _pbdlPath;
+  String get pbdlPath => _pbdlPath;
+  set pbdlPath(String path) => _pbdlPath = _validatePath(path);
+
+  /// Specific [configuration] items specified by the user, or attributes that
+  /// are derived straight from the configuration items that the user provided.
+  ///
+  /// For example, some of the configuration that are derived is the [GenerationConfiguration],
+  /// based on the JSON file the user used for configuration.
   PBConfiguration configuration;
 
   // the type of configuration you want to set, 'default' is default type.
@@ -26,7 +61,9 @@ class MainInfo {
   String deviceId;
 
   /// Name of the project
-  String projectName;
+  String _projectName;
+  String get projectName => _projectName ?? configuration?.projectName;
+  set projectName(String name) => _projectName = name;
 
   /// API needed to do API callls
   String figmaKey;
@@ -37,7 +74,37 @@ class MainInfo {
   /// Boolean that indicates whether a `styles` document is created.
   bool exportStyles;
 
+  /// Exporting the PBDL JSON file instead of generating the actual Flutter code.
+  bool exportPBDL;
+
   Map pbdf;
+
+  /// Type of [DesignType] that is being processed by the current process of
+  /// Parabeac Core.
+  DesignType designType;
+
+  /// Where the assets are going to be generating through the process.
+  String _pngPath;
+  String get pngPath => _pngPath;
+  set pngPath(String path) => _pngPath = _validatePath(path ?? _defaultPNGPath);
+
+  String get _defaultPNGPath => p.join(outputPath ?? cwd, 'pngs');
+
+  /// Checks if the [path] is `null`, if its not, it will [p.absolute] and finally,
+  /// run [p.normalize] on the [path].
+  ///
+  /// This is primarly to enforce absolute and correct paths in the [MainInfo]
+  String _validatePath(String path) {
+    if (path == null) {
+      return path;
+    }
+    return p.normalize(p.absolute(path));
+  }
+
+  /// Decoupling the exception capture client from the services that report the [exception]
+  void captureException(exception) {
+    _sentry.captureException(exception: exception);
+  }
 
   factory MainInfo() {
     return _singleton;
@@ -45,3 +112,6 @@ class MainInfo {
 
   MainInfo._internal();
 }
+
+/// The type of design that is being processed by Parabeac Core.
+enum DesignType { SKETCH, FIGMA, PBDL, UNKNOWN }

--- a/lib/controllers/sketch_controller.dart
+++ b/lib/controllers/sketch_controller.dart
@@ -33,7 +33,7 @@ class SketchController extends Controller {
 
     AzureAssetService().projectUUID = designProject.id;
 
-    super.convert(designProject , apService ?? SketchAssetProcessor());
+    super.convert(designProject, apService ?? SketchAssetProcessor());
   }
 
   SketchProject generateSketchNodeTree(
@@ -82,7 +82,7 @@ class SketchController extends Controller {
 
       process = await Process.start('npm', ['run', 'prod'],
           workingDirectory:
-              p.join(MainInfo().cwd.path, '/SketchAssetConverter'));
+              p.join(MainInfo().cwd.path, 'SketchAssetConverter'));
 
       await for (var event in process.stdout.transform(utf8.decoder)) {
         if (event.toLowerCase().contains('server is listening on port')) {

--- a/lib/controllers/sketch_controller.dart
+++ b/lib/controllers/sketch_controller.dart
@@ -1,44 +1,39 @@
+import 'dart:io';
+import 'dart:convert';
+
 import 'package:parabeac_core/controllers/controller.dart';
 import 'package:parabeac_core/input/helper/asset_processing_service.dart';
 import 'package:parabeac_core/input/helper/azure_asset_service.dart';
 
 import 'package:parabeac_core/input/helper/design_project.dart';
+import 'package:parabeac_core/input/sketch/helper/sketch_asset_processor.dart';
 import 'package:parabeac_core/input/sketch/helper/sketch_project.dart';
 import 'package:parabeac_core/input/sketch/services/input_design.dart';
-import 'package:quick_log/quick_log.dart';
 
 import 'main_info.dart';
+import 'package:path/path.dart' as p;
 
 class SketchController extends Controller {
-  ///SERVICE
   @override
-  var log = Logger('SketchController');
+  DesignType get designType => DesignType.SKETCH;
 
   ///Converting the [fileAbsPath] sketch file to flutter
   @override
-  void convertFile(
-    var fileAbsPath,
-    var projectPath,
-    configuration, {
-    bool jsonOnly = false,
+  void convertFile({
     DesignProject designProject,
     AssetProcessingService apService,
   }) async {
+    var processInfo = MainInfo();
+
     ///INTAKE
-    var ids = InputDesignService(fileAbsPath, jsonOnly: jsonOnly);
-    var sketchProject = generateSketchNodeTree(
-        ids, ids.metaFileJson['pagesAndArtboards'], projectPath);
+    var ids = InputDesignService(processInfo.designFilePath,
+        jsonOnly: processInfo.exportPBDL);
+    designProject ??= generateSketchNodeTree(
+        ids, ids.metaFileJson['pagesAndArtboards'], processInfo.genProjectPath);
 
-    AzureAssetService().projectUUID = sketchProject.id;
+    AzureAssetService().projectUUID = designProject.id;
 
-    super.convertFile(
-      fileAbsPath,
-      projectPath,
-      configuration,
-      designProject: sketchProject,
-      jsonOnly: jsonOnly,
-      apService: apService,
-    );
+    super.convert(designProject , apService ?? SketchAssetProcessor());
   }
 
   SketchProject generateSketchNodeTree(
@@ -52,6 +47,50 @@ class SketchController extends Controller {
           );
       log.error(e.toString());
       return null;
+    }
+  }
+
+  @override
+  Future<void> setup() async {
+    var processInfo = MainInfo();
+    if (!processInfo.exportPBDL) {
+      if (!FileSystemEntity.isFileSync(processInfo.designFilePath)) {
+        throw Error();
+      }
+      InputDesignService(processInfo.designFilePath);
+      await checkSACVersion();
+    }
+    await super.setup();
+  }
+
+  Future<void> checkSACVersion() async {
+    /// Code is moved from `main.dart`
+    Process process;
+    if (!Platform.environment.containsKey('SAC_ENDPOINT')) {
+      var isSACupToDate = await Process.run(
+        './pb-scripts/check-git.sh',
+        [],
+        workingDirectory: MainInfo().cwd.path,
+      );
+
+      if (isSACupToDate.stdout
+          .contains('Sketch Asset Converter is behind master.')) {
+        log.warning(isSACupToDate.stdout);
+      } else {
+        log.info(isSACupToDate.stdout);
+      }
+
+      process = await Process.start('npm', ['run', 'prod'],
+          workingDirectory:
+              p.join(MainInfo().cwd.path, '/SketchAssetConverter'));
+
+      await for (var event in process.stdout.transform(utf8.decoder)) {
+        if (event.toLowerCase().contains('server is listening on port')) {
+          log.fine('Successfully started Sketch Asset Converter');
+          break;
+        }
+      }
+      process?.kill();
     }
   }
 }

--- a/lib/design_logic/boolean_operation.dart
+++ b/lib/design_logic/boolean_operation.dart
@@ -34,7 +34,7 @@ class BooleanOperation implements DesignNodeFactory, DesignNode {
   Future<PBIntermediateNode> interpretNode(PBContext currentContext) async {
     var img = await AzureAssetService().downloadImage(UUID);
     var path =
-        p.join(MainInfo().outputPath, 'pngs', '$UUID.png'.replaceAll(':', '_'));
+        p.join(MainInfo().pngPath, '$UUID.png'.replaceAll(':', '_'));
     var file = File(path)..createSync(recursive: true);
     file.writeAsBytesSync(img);
 

--- a/lib/design_logic/image.dart
+++ b/lib/design_logic/image.dart
@@ -95,7 +95,7 @@ class Image extends DesignElement implements DesignNodeFactory, DesignNode {
   @override
   Future<PBIntermediateNode> interpretNode(PBContext currentContext) async {
     var pngsPath =
-        p.join(MainInfo().outputPath, 'pngs', '$UUID.png'.replaceAll(':', '_'));
+        p.join(MainInfo().pngPath, '$UUID.png'.replaceAll(':', '_'));
     try {
       var img = await AzureAssetService().downloadImage(UUID);
       var file = File(pngsPath)..createSync(recursive: true);

--- a/lib/design_logic/vector.dart
+++ b/lib/design_logic/vector.dart
@@ -108,7 +108,7 @@ class Vector implements DesignNodeFactory, DesignNode, Image {
     imageReference = AssetProcessingService.getImageName(UUID);
 
     var pngsPath =
-        p.join(MainInfo().outputPath, 'pngs', '$UUID.png'.replaceAll(':', '_'));
+        p.join(MainInfo().pngPath, '$UUID.png'.replaceAll(':', '_'));
     var file = File(pngsPath)..createSync(recursive: true);
     file.writeAsBytesSync(img);
     return Future.value(

--- a/lib/generation/generators/value_objects/generation_configuration/pb_generation_configuration.dart
+++ b/lib/generation/generators/value_objects/generation_configuration/pb_generation_configuration.dart
@@ -1,3 +1,4 @@
+import 'package:parabeac_core/controllers/main_info.dart';
 import 'package:parabeac_core/generation/flutter_project_builder/import_helper.dart';
 import 'package:parabeac_core/generation/generators/import_generator.dart';
 import 'package:parabeac_core/generation/generators/middleware/command_gen_middleware.dart';
@@ -106,6 +107,7 @@ abstract class GenerationConfiguration with PBPlatformOrientationGeneration {
 
   ///Generates the [PBIntermediateTree]s within the [pb_project]
   Future<void> generateProject(PBProject pb_project) async {
+    var processInfo = MainInfo();
     _head = CommandGenMiddleware(
         generationManager, this, _importProcessor, pb_project.projectName);
 
@@ -129,7 +131,7 @@ abstract class GenerationConfiguration with PBPlatformOrientationGeneration {
     commandQueue.clear();
     await generateTrees(pb_project.forest, pb_project);
 
-    await _commitDependencies(pb_project.projectAbsPath);
+    await _commitDependencies(processInfo.genProjectPath);
   }
 
   void registerMiddleware(Middleware middleware) {

--- a/lib/input/figma/helper/figma_asset_processor.dart
+++ b/lib/input/figma/helper/figma_asset_processor.dart
@@ -86,7 +86,7 @@ class FigmaAssetProcessor extends AssetProcessingService {
                 }
 
                 if (writeAsFile) {
-                  var pngsPath = p.join(MainInfo().outputPath, 'pngs',
+                  var pngsPath = p.join(MainInfo().pngPath,
                       '${entry.key}.png'.replaceAll(':', '_'));
                   var file = File(pngsPath)..createSync(recursive: true);
                   file.writeAsBytesSync(imageRes.bodyBytes);

--- a/lib/input/sketch/helper/sketch_asset_processor.dart
+++ b/lib/input/sketch/helper/sketch_asset_processor.dart
@@ -33,12 +33,12 @@ class SketchAssetProcessor extends AssetProcessingService {
               'uuid': uuid,
               'width': width,
               'height': height,
-              'blob': getBlobName(MainInfo().sketchPath),
+              'blob': getBlobName(MainInfo().designFilePath),
               'container': 'design-file'
             }
           : {
               'uuid': uuid,
-              'path': MainInfo().sketchPath,
+              'path': MainInfo().designFilePath,
               'width': width,
               'height': height
             };

--- a/lib/input/sketch/services/input_design.dart
+++ b/lib/input/sketch/services/input_design.dart
@@ -8,7 +8,7 @@ import 'package:path/path.dart' as p;
 
 /// Takes Initial Design File and puts it into a tree in object format.
 /// Currently only supports Sketch Files
-///Class used to process the contents of a sketch file
+/// Class used to process the contents of a sketch file
 class InputDesignService {
   final String pathToFile;
   final String IMAGE_DIR_NAME = 'images/';
@@ -44,7 +44,7 @@ class InputDesignService {
   ///Getting the images in the sketch file and adding them to the png folder.
   void setImageDir() {
     ///Creating the pngs folder, if it's already not there.
-    var pngsPath = p.join(MainInfo().outputPath, 'pngs');
+    var pngsPath = p.join(MainInfo().pngPath);
     Directory(pngsPath).createSync(recursive: true);
     for (final file in archive) {
       final fileName = file.name;

--- a/lib/interpret_and_optimize/helpers/pb_configuration.dart
+++ b/lib/interpret_and_optimize/helpers/pb_configuration.dart
@@ -28,8 +28,6 @@ class PBConfiguration {
 
   String outputDirPath;
 
-  String get genProjectPath => p.join(outputDirPath, projectName);
-
   @JsonKey(defaultValue: 'Material')
   final String widgetStyle;
 

--- a/lib/interpret_and_optimize/helpers/pb_image_reference_storage.dart
+++ b/lib/interpret_and_optimize/helpers/pb_image_reference_storage.dart
@@ -25,7 +25,7 @@ class ImageReferenceStorage {
   /// Adds the reference to the image and writes the png to the assets folder.
   /// Returns true if the image was written successfully, false otherwise
   bool addReferenceAndWrite(String name, String path, Uint8List image) {
-    var imgPath = p.join(MainInfo().outputPath, 'pngs', '$name.png');
+    var imgPath = p.join(MainInfo().pngPath, '$name.png');
     if (image == null &&
         File('${MainInfo().cwd?.path}/lib/input/assets/image-conversion-error.png')
             .existsSync() &&

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,11 +4,6 @@ import 'package:parabeac_core/controllers/design_controller.dart';
 import 'package:parabeac_core/controllers/figma_controller.dart';
 import 'package:parabeac_core/controllers/main_info.dart';
 import 'package:parabeac_core/controllers/sketch_controller.dart';
-import 'package:parabeac_core/input/figma/helper/api_call_service.dart';
-import 'package:parabeac_core/input/figma/helper/figma_asset_processor.dart';
-import 'package:parabeac_core/input/helper/azure_asset_service.dart';
-import 'package:parabeac_core/input/sketch/helper/sketch_asset_processor.dart';
-import 'package:parabeac_core/input/sketch/services/input_design.dart';
 import 'package:parabeac_core/interpret_and_optimize/helpers/pb_configuration.dart';
 import 'package:parabeac_core/interpret_and_optimize/helpers/pb_plugin_list_helper.dart';
 import 'package:quick_log/quick_log.dart';
@@ -16,19 +11,44 @@ import 'package:sentry/sentry.dart';
 import 'package:uuid/uuid.dart';
 import 'package:http/http.dart' as http;
 import 'package:args/args.dart';
+import 'controllers/controller.dart';
 import 'controllers/main_info.dart';
 import 'package:yaml/yaml.dart';
 import 'package:path/path.dart' as p;
 
-ArgResults argResults;
+var controllers = <Controller>[
+  FigmaController(),
+  SketchController(),
+  DesignController()
+];
 
+///sets up parser
+final parser = ArgParser()
+  ..addOption('path',
+      help: 'Path to the design file', valueHelp: 'path', abbr: 'p')
+  ..addOption('out', help: 'The output path', valueHelp: 'path', abbr: 'o')
+  ..addOption('project-name',
+      help: 'The name of the project', abbr: 'n', defaultsTo: 'temp')
+  ..addOption('config-path',
+      help: 'Path of the configuration file',
+      abbr: 'c',
+      defaultsTo:
+          '${p.setExtension(p.join('lib/configurations/', 'configurations'), '.json')}')
+  ..addOption('fig', help: 'The ID of the figma file', abbr: 'f')
+  ..addOption('figKey', help: 'Your personal API Key', abbr: 'k')
+  ..addOption(
+    'pbdl-in',
+    help:
+        'Takes in a Parabeac Design Logic (PBDL) JSON file and exports it to a project',
+  )
+  ..addFlag('help',
+      help: 'Displays this help information.', abbr: 'h', negatable: false)
+  ..addFlag('export-pbdl',
+      help: 'This flag outputs Parabeac Design Logic (PBDL) in JSON format.')
+  ..addFlag('exclude-styles',
+      help: 'If this flag is set, it will exclude output styles document');
 void main(List<String> args) async {
   await checkConfigFile();
-
-  //Sentry logging initialization
-  MainInfo().sentry = SentryClient(
-      dsn:
-          'https://6e011ce0d8cd4b7fb0ff284a23c5cb37@o433482.ingest.sentry.io/5388747');
   var log = Logger('Main');
   var pubspec = File('pubspec.yaml');
   await pubspec.readAsString().then((String text) {
@@ -39,32 +59,6 @@ void main(List<String> args) async {
 
   MainInfo().cwd = Directory.current;
 
-  ///sets up parser
-  final parser = ArgParser()
-    ..addOption('path',
-        help: 'Path to the design file', valueHelp: 'path', abbr: 'p')
-    ..addOption('out', help: 'The output path', valueHelp: 'path', abbr: 'o')
-    ..addOption('project-name',
-        help: 'The name of the project', abbr: 'n', defaultsTo: 'temp')
-    ..addOption('config-path',
-        help: 'Path of the configuration file',
-        abbr: 'c',
-        defaultsTo:
-            '${p.setExtension(p.join('lib/configurations/', 'configurations'), '.json')}')
-    ..addOption('fig', help: 'The ID of the figma file', abbr: 'f')
-    ..addOption('figKey', help: 'Your personal API Key', abbr: 'k')
-    ..addOption(
-      'pbdl-in',
-      help:
-          'Takes in a Parabeac Design Logic (PBDL) JSON file and exports it to a project',
-    )
-    ..addFlag('help',
-        help: 'Displays this help information.', abbr: 'h', negatable: false)
-    ..addFlag('export-pbdl',
-        help: 'This flag outputs Parabeac Design Logic (PBDL) in JSON format.')
-    ..addFlag('exclude-styles',
-        help: 'If this flag is set, it will exclude output styles document');
-
 //error handler using logger package
   void handleError(String msg) {
     log.error(msg);
@@ -72,171 +66,91 @@ void main(List<String> args) async {
     exit(2);
   }
 
-  argResults = parser.parse(args);
+  var argResults = parser.parse(args);
 
-  //Check if no args passed or only -h/--help passed
+  /// Check if no args passed or only -h/--help passed
   if (argResults['help'] || argResults.arguments.isEmpty) {
     print('''
   ** PARABEAC HELP **
 ${parser.usage}
     ''');
     exit(0);
-  }
-
-  var configuration =
-      generateConfiguration(p.normalize(argResults['config-path']));
-
-  // Detect platform
-  MainInfo().platform = Platform.operatingSystem;
-  configuration.platform = Platform.operatingSystem;
-
-  String path = argResults['path'];
-
-  MainInfo().figmaKey = argResults['figKey'];
-  MainInfo().figmaProjectID = argResults['fig'];
-
-  var designType = 'sketch';
-  MainInfo().exportStyles = !argResults['exclude-styles'];
-  var jsonOnly = argResults['export-pbdl'];
-
-  // var configurationPath = argResults['config-path'];
-  // var configurationType = 'default';
-  String projectName = argResults['project-name'];
-
-  // Handle input errors
-  if (hasTooFewArgs(argResults)) {
+  } else if (hasTooFewArgs(argResults)) {
     handleError(
         'Missing required argument: path to Sketch file or both Figma Key and Project ID.');
   } else if (hasTooManyArgs(argResults)) {
     handleError(
         'Too many arguments: Please provide either the path to Sketch file or the Figma File ID and API Key');
-  } else if (argResults['figKey'] != null && argResults['fig'] != null) {
-    designType = 'figma';
-  } else if (argResults['path'] != null) {
-    designType = 'sketch';
-  } else if (argResults['pbdl-in'] != null) {
-    designType = 'pbdl';
   }
 
-  // Populate `MainInfo()`
-
-  // If outputPath is empty, assume we are outputting to design file path
-  MainInfo().outputPath = (p.absolute(
-      p.normalize(argResults['out'] ?? p.dirname(path ?? Directory.current))));
-  configuration.outputDirPath = MainInfo().outputPath;
-
-  MainInfo().projectName = projectName;
-  configuration.projectName = projectName;
-  MainInfo().configuration = configuration;
-
-  // Create pngs directory
-  var pngsPath = p.join(MainInfo().outputPath,
-      (jsonOnly || argResults['pbdl-in'] != null ? '' : 'pngs'));
-  await Directory(pngsPath).create(recursive: true);
-
-  if (designType == 'sketch') {
-    if (argResults['pbdl-in'] != null) {
-      var pbdlPath = argResults['pbdl-in'];
-      var jsonString = File(pbdlPath).readAsStringSync();
-      MainInfo().pbdf = json.decode(jsonString);
-    }
-    Process process;
-    if (!jsonOnly) {
-      var file = await FileSystemEntity.isFile(path);
-      var exists = await File(path).exists();
-
-      if (!file || !exists) {
-        handleError('$path is not a file');
-      }
-      MainInfo().sketchPath = p.normalize(p.absolute(path));
-      InputDesignService(path);
-
-      if (!Platform.environment.containsKey('SAC_ENDPOINT')) {
-        var isSACupToDate = await Process.run(
-          './pb-scripts/check-git.sh',
-          [],
-          workingDirectory: MainInfo().cwd.path,
-        );
-
-        if (isSACupToDate.stdout
-            .contains('Sketch Asset Converter is behind master.')) {
-          log.warning(isSACupToDate.stdout);
-        } else {
-          log.info(isSACupToDate.stdout);
-        }
-
-        process = await Process.start('npm', ['run', 'prod'],
-            workingDirectory: MainInfo().cwd.path + '/SketchAssetConverter');
-
-        await for (var event in process.stdout.transform(utf8.decoder)) {
-          if (event.toLowerCase().contains('server is listening on port')) {
-            log.fine('Successfully started Sketch Asset Converter');
-            break;
-          }
-        }
-      }
-    }
-
-    SketchController().convertFile(
-      path,
-      MainInfo().outputPath + projectName,
-      configuration,
-      jsonOnly: jsonOnly,
-      apService: SketchAssetProcessor(),
-    );
-    process?.kill();
-  } else if (designType == 'xd') {
-    assert(false, 'We don\'t support Adobe XD.');
-  } else if (designType == 'figma') {
-    if (argResults['pbdl-in'] != null) {
-      var pbdlPath = argResults['pbdl-in'];
-      var jsonString = File(pbdlPath).readAsStringSync();
-      MainInfo().pbdf = json.decode(jsonString);
-    }
-    if (MainInfo().figmaKey == null || MainInfo().figmaKey.isEmpty) {
-      assert(false, 'Please provided a Figma API key to proceed.');
-    }
-    if (MainInfo().figmaProjectID == null ||
-        MainInfo().figmaProjectID.isEmpty) {
-      assert(false, 'Please provided a Figma project ID to proceed.');
-    }
-    var jsonOfFigma = await APICallService.makeAPICall(
-        'https://api.figma.com/v1/files/${MainInfo().figmaProjectID}',
-        MainInfo().figmaKey);
-
-    if (jsonOfFigma != null) {
-      AzureAssetService().projectUUID = MainInfo().figmaProjectID;
-      // Starts Figma to Object
-      FigmaController().convertFile(
-        jsonOfFigma,
-        MainInfo().outputPath + projectName,
-        configuration,
-        jsonOnly: jsonOnly,
-        apService: FigmaAssetProcessor(),
-      );
-    } else {
-      log.error('File was not retrieved from Figma.');
-    }
-  } else if (designType == 'pbdl') {
-    var pbdlPath = argResults['pbdl-in'];
-    var isFile = FileSystemEntity.isFileSync(pbdlPath);
-    var exists = File(pbdlPath).existsSync();
-
-    if (!isFile || !exists) {
-      handleError('$path is not a file');
-    }
-
-    var jsonString = await File(pbdlPath).readAsString();
-
-    var pbdf = json.decode(jsonString);
-
-    DesignController().convertFile(
-      pbdf,
-      MainInfo().outputPath + projectName,
-      configuration,
-    );
+  collectArguments(argResults);
+  var processInfo = MainInfo();
+  if (processInfo.designType == DesignType.UNKNOWN) {
+    throw UnsupportedError('We have yet to support this DesignType! ');
   }
+
+  var controller = controllers.firstWhere(
+      (controller) => controller.designType == processInfo.designType);
+  await controller.setup();
+  controller.convertFile();
+
   exitCode = 0;
+}
+
+/// Populates the corresponding fields of the [MainInfo] object with the
+/// corresponding [arguments].
+///
+/// Remember that [MainInfo] is a Singleton, therefore, nothing its going to
+/// be return from the function. When you use [MainInfo] again, its going to
+/// contain the proper values from [arguments]
+void collectArguments(ArgResults arguments) {
+  var info = MainInfo();
+
+  info.configuration =
+      generateConfiguration(p.normalize(arguments['config-path']));
+
+  /// Detect platform
+  info.platform = Platform.operatingSystem;
+
+  info.figmaKey = arguments['figKey'];
+  info.figmaProjectID = arguments['fig'];
+
+  info.designFilePath = arguments['path'];
+  if (arguments['pbdl-in'] != null) {
+    info.pbdlPath = arguments['pbdl-in'];
+  }
+
+  info.designType = determineDesignTypeFromArgs(arguments);
+  info.exportStyles = !arguments['exclude-styles'];
+  info.projectName ??= arguments['project-name'];
+
+  /// If outputPath is empty, assume we are outputting to design file path
+  info.outputPath =
+      arguments['out'] ?? p.dirname(info.designFilePath ?? Directory.current);
+
+  info.exportPBDL = arguments['export-pbdl'] ?? false;
+  
+  /// In the future when we are generating certain dart files only.
+  /// At the moment we are only generating in the flutter project.
+  info.pngPath = p.join(info.genProjectPath, 'assets/images');
+}
+
+/// Determine the [MainInfo.designType] from the [arguments]
+///
+/// If [arguments] include `figKey` or `fig`, that implies that [MainInfo.designType]
+/// should be [DesignType.FIGMA]. If there is a `path`, then the [MainInfo.designType]
+/// should be [DesignType.SKETCH]. Otherwise, if it includes the flag `pndl-in`, the type
+/// is [DesignType.PBDL].Finally, if none of the [DesignType] applies, its going to default
+/// to [DesignType.UNKNOWN].
+DesignType determineDesignTypeFromArgs(ArgResults arguments) {
+  if (arguments['figKey'] != null && arguments['fig'] != null) {
+    return DesignType.FIGMA;
+  } else if (arguments['path'] != null) {
+    return DesignType.SKETCH;
+  } else if (arguments['pbdl-in'] != null) {
+    return DesignType.PBDL;
+  }
+  return DesignType.UNKNOWN;
 }
 
 /// Checks whether a configuration file is made already,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -126,7 +126,7 @@ void collectArguments(ArgResults arguments) {
 
   /// If outputPath is empty, assume we are outputting to design file path
   info.outputPath =
-      arguments['out'] ?? p.dirname(info.designFilePath ?? Directory.current);
+      arguments['out'] ?? p.dirname(info.designFilePath ?? Directory.current.path);
 
   info.exportPBDL = arguments['export-pbdl'] ?? false;
   

--- a/test/lib/input_services/edge_adjacent_detection_test.dart
+++ b/test/lib/input_services/edge_adjacent_detection_test.dart
@@ -28,6 +28,7 @@ void main() {
       sketchNode = ShapePathMock();
       context = ContextMock();
       MainInfo().outputPath = '';
+      MainInfo().pngPath = '';
 
       when(sketchNode.points).thenReturn([
         {
@@ -132,6 +133,7 @@ void main() {
       when(sketchNode.UUID).thenReturn('');
       shapePath =
           InheritedShapePath(sketchNode, 'testName', currentContext: context);
+      
     });
 
     test('Detecting Shape', () {

--- a/test/lib/output_services/png_gen_test.dart
+++ b/test/lib/output_services/png_gen_test.dart
@@ -19,7 +19,7 @@ void main() async {
 
   group('Local Sketch PNG Testing:', () {
     setUpAll(() async {
-      MainInfo().sketchPath =
+      MainInfo().designFilePath =
           '${Directory.current.path}/test/assets/parabeac_demo_alt.sketch';
       uuids = [
         '85D93FCD-5A69-4DAF-AE90-351CD9B64554', // Shape Group
@@ -58,7 +58,7 @@ void main() async {
 
   group('Github Sketch PNG Testing:', () {
     setUpAll(() async {
-      MainInfo().sketchPath =
+      MainInfo().designFilePath =
           '${Directory.current.path}/test/assets/parabeac_demo_alt.sketch';
       uuids = [
         '85D93FCD-5A69-4DAF-AE90-351CD9B64554', // Shape Group
@@ -94,7 +94,7 @@ void main() async {
       await FigmaAssetProcessor().processImageQueue();
       for (var uuid in FigmaAssetProcessor().uuidQueue) {
         expect(
-            File(p.join(MainInfo().outputPath, 'pngs',
+            File(p.join(MainInfo().pngPath,
                     '$uuid.png'.replaceAll(':', '_')))
                 .existsSync(),
             true);

--- a/test/lib/output_services/project_builder_test.dart
+++ b/test/lib/output_services/project_builder_test.dart
@@ -106,7 +106,7 @@ void main() {
       when(mockConfig.fileStructureStrategy).thenReturn(fss);
 
       projectBuilder = FlutterProjectBuilder(mockConfig,
-          genProjectAbsPath: Directory.current.path,
+          // genProjectAbsPath: Directory.current.path,
           project: project,
           pageWriter: PBFlutterWriter());
     });
@@ -116,7 +116,7 @@ void main() {
         /// Check that the Dart file was created
         /// It should be a file named `testingPage`
         /// Stafefulwidget with a Scaffold and a Container
-        await projectBuilder.convertToFlutterProject();
+        await projectBuilder.genProjectFiles();
       },
       timeout: Timeout(
         Duration(minutes: 1),

--- a/test/lib/output_services/project_builder_test.dart
+++ b/test/lib/output_services/project_builder_test.dart
@@ -106,7 +106,9 @@ void main() {
       when(mockConfig.fileStructureStrategy).thenReturn(fss);
 
       projectBuilder = FlutterProjectBuilder(mockConfig,
-          project: project, pageWriter: PBFlutterWriter());
+          genProjectAbsPath: Directory.current.path,
+          project: project,
+          pageWriter: PBFlutterWriter());
     });
     test(
       '',


### PR DESCRIPTION
- Primarily, I fixed the issue with the pngs being generated in the incorrect place (if the name flag is used). Instead of the pngs being developed in a `temp` folder then moving to the correct one, the pngs are generated in the right assets folder from the start.  It's done by separating _flutter project creation_ and generating the dart files within the project; since we can determine if it will be a flutter project from the start, we can create the project and have the `png path` become the correct one.
- Secondly, and probably the most significant change, is the decoupling of the controller classes with the `main.dart` file. There were if statements that configured each of the controllers based on the type of design file. A controller is chosen from the list based on the corresponding design type, then configured, and finally, start ingesting the design file.
- Finally, added/removed attributes, getters, and functions to the `MainInfo()` Singleton for better access to information across the PBC's lifecycle.
