### PR TITLE
Fix State management interpretation

### DIFF
--- a/lib/interpret_and_optimize/entities/pb_shared_instance.dart
+++ b/lib/interpret_and_optimize/entities/pb_shared_instance.dart
@@ -1,4 +1,5 @@
 import 'package:parabeac_core/generation/generators/symbols/pb_instancesym_gen.dart';
+import 'package:parabeac_core/generation/generators/util/pb_input_formatter.dart';
 import 'package:parabeac_core/generation/prototyping/pb_prototype_node.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/interfaces/pb_inherited_intermediate.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/subclasses/pb_intermediate_constraints.dart';
@@ -91,6 +92,7 @@ class PBSharedInstanceIntermediateNode extends PBVisualIntermediateNode
   PBIntermediateNode createIntermediateNode(Map<String, dynamic> json,
       PBIntermediateNode parent, PBIntermediateTree tree) {
     var instance = PBSharedInstanceIntermediateNode.fromJson(json);
+    instance.name = PBInputFormatter.formatPageName(instance.name);
     _formatOverrideVals(
         (instance as PBSharedInstanceIntermediateNode).sharedParamValues);
     return instance;

--- a/lib/interpret_and_optimize/helpers/pb_state_management_helper.dart
+++ b/lib/interpret_and_optimize/helpers/pb_state_management_helper.dart
@@ -49,10 +49,13 @@ class PBStateManagementHelper {
   ///
   /// Returns `null` if `node` has no `DirectedStateGraph`
   DirectedStateGraph getStateGraphOfNode(PBIntermediateNode node) {
-    if (isValidStateNode(node.name) &&
+    var identifier = node is PBSharedInstanceIntermediateNode
+        ? node.functionCallName
+        : node.name;
+    if (isValidStateNode(identifier) &&
         (node is PBSharedMasterNode ||
             node is PBSharedInstanceIntermediateNode)) {
-      var rootNodeName = _getNodeName(node.name);
+      var rootNodeName = _getNodeName(identifier);
       return linker.getDirectedStateGraphOfName(rootNodeName);
     }
     return null;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -117,12 +117,12 @@ ${parser.usage}
     (service) => service.designType == processInfo.designType,
   );
   var pbdl = await pbdlService.callPBDL(processInfo);
-  var pbProject = PBProject.fromJson(pbdl.toJson());
   // Exit if only generating PBDL
   if (MainInfo().exportPBDL) {
     exitCode = 0;
     return;
   }
+  var pbProject = PBProject.fromJson(pbdl.toJson());
   pbProject.projectAbsPath =
       p.join(processInfo.outputPath, processInfo.projectName);
 


### PR DESCRIPTION
Mainly, the issue was when a designer changed the name of an Instance. Rather than use the name of an instance, we use the `functionCallName` to identify whether it has any states.