### PR TITLE
Feat/comp isolation

### DIFF
--- a/lib/generation/flutter_project_builder/flutter_project_builder.dart
+++ b/lib/generation/flutter_project_builder/flutter_project_builder.dart
@@ -65,7 +65,7 @@ class FlutterProjectBuilder {
   static Future<Tuple2> createFlutterProject(String flutterProjectName,
       {String projectDir,
       bool createAssetsDir = true,
-      String assetsDir = 'assets/images/'}) async {
+      String assetsDir = 'lib/assets/images/'}) async {
     try {
       var result = await Process.run('flutter', ['create', flutterProjectName],
           workingDirectory: projectDir, runInShell: true);

--- a/lib/generation/generators/value_objects/file_structure_strategy/commands/add_dependency_command.dart
+++ b/lib/generation/generators/value_objects/file_structure_strategy/commands/add_dependency_command.dart
@@ -1,3 +1,4 @@
+import 'package:parabeac_core/controllers/main_info.dart';
 import 'package:parabeac_core/generation/generators/value_objects/file_structure_strategy/commands/file_structure_command.dart';
 import 'package:parabeac_core/generation/generators/value_objects/file_structure_strategy/pb_file_structure_strategy.dart';
 
@@ -6,7 +7,8 @@ class AddDependencyCommand extends FileStructureCommand {
   final _PUBSPEC_YAML_NAME = 'pubspec.yaml';
 
   ///assets yaml decleration
-  final String _ASSET_DECLERATION = '\t\t- assets/images/';
+  final String _ASSET_DECLERATION =
+      '\t\t- packages/${MainInfo().projectName}/assets/images/';
 
   /// Name of the [package]
   String package;

--- a/lib/generation/generators/visual-widgets/pb_bitmap_gen.dart
+++ b/lib/generation/generators/visual-widgets/pb_bitmap_gen.dart
@@ -40,8 +40,11 @@ class PBBitmapGenerator extends PBGenerator {
         ? 'assets/${source.referenceImage}' // Assuming PBDL will give us reference to image in the form of `image/<image_name>.png`
         : ('assets/images/' + source.UUID + '.png');
 
-    buffer.write(
-        '\'$imagePath\', ${_sizehelper.generate(source, generatorContext)} $boxFit)');
+    buffer.write('\'$imagePath\', ');
+    // Point package to self (for component isolation support)
+    buffer.write('package: \'${MainInfo().projectName}\',');
+    buffer.write('${_sizehelper.generate(source, generatorContext)} $boxFit)');
+
     return buffer.toString();
   }
 

--- a/lib/generation/generators/visual-widgets/pb_shape_group_gen.dart
+++ b/lib/generation/generators/visual-widgets/pb_shape_group_gen.dart
@@ -1,3 +1,4 @@
+import 'package:parabeac_core/controllers/main_info.dart';
 import 'package:parabeac_core/generation/generators/attribute-helper/pb_size_helper.dart';
 import 'package:parabeac_core/generation/generators/pb_generator.dart';
 import 'package:parabeac_core/interpret_and_optimize/entities/inherited_shape_group.dart';
@@ -15,7 +16,7 @@ class PBShapeGroupGen extends PBGenerator {
     if (source is InheritedShapeGroup) {
       var buffer = StringBuffer();
       buffer.write(
-          'Image.asset(\'assets/images/${source.UUID}.png\', ${_sizehelper.generate(source)})');
+          'Image.asset(\'assets/images/${source.UUID}.png\', ${_sizehelper.generate(source)}), package: \'${MainInfo().projectName}\',');
       return buffer.toString();
     }
   }

--- a/lib/interpret_and_optimize/services/design_to_pbdl/figma_to_pbdl_service.dart
+++ b/lib/interpret_and_optimize/services/design_to_pbdl/figma_to_pbdl_service.dart
@@ -12,8 +12,9 @@ class FigmaToPBDLService implements DesignToPBDLService {
     return PBDL.fromFigma(
       info.figmaProjectID,
       info.figmaKey,
+      outputPath: p.join(info.genProjectPath, 'assets'),
       // Generating all assets inside lib folder for package isolation
-      outputPath: p.join(info.genProjectPath, 'lib', 'assets'),
+      pngPath: p.join(info.genProjectPath, 'lib', 'assets', 'images'),
       exportPbdlJson: info.exportPBDL,
       projectName: info.projectName,
     );

--- a/lib/interpret_and_optimize/services/design_to_pbdl/figma_to_pbdl_service.dart
+++ b/lib/interpret_and_optimize/services/design_to_pbdl/figma_to_pbdl_service.dart
@@ -12,7 +12,8 @@ class FigmaToPBDLService implements DesignToPBDLService {
     return PBDL.fromFigma(
       info.figmaProjectID,
       info.figmaKey,
-      outputPath: p.join(info.genProjectPath, 'assets'),
+      // Generating all assets inside lib folder for package isolation
+      outputPath: p.join(info.genProjectPath, 'lib', 'assets'),
       exportPbdlJson: info.exportPBDL,
       projectName: info.projectName,
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -285,7 +285,7 @@ void collectArguments(ArgResults arguments) {
 
   /// In the future when we are generating certain dart files only.
   /// At the moment we are only generating in the flutter project.
-  info.pngPath = p.join(info.genProjectPath, 'assets/images');
+  info.pngPath = p.join(info.genProjectPath, 'lib/assets/images');
 }
 
 /// Determine the [MainInfo.designType] from the [arguments]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
     path: ./pbdl
   directed_graph: ^0.2.3
   sentry: ^6.2.2
+  yaml_modify: ^1.0.1
 
 dev_dependencies:
   pedantic: ^1.8.0


### PR DESCRIPTION
* Generate assets inside `lib` folder.
    * This was done in order to support component isolation, as all available assets to external devs must be in the lib folder.
* Generate images with `package` property.
* Generate all images into `pubspec.yaml`