### PR TITLE
Add OAuth option to core for figma

### DIFF
--- a/lib/controllers/main_info.dart
+++ b/lib/controllers/main_info.dart
@@ -57,7 +57,10 @@ class MainInfo {
   String get projectName => _projectName ?? configuration?.projectName;
   set projectName(String name) => _projectName = name;
 
-  /// API needed to do API callls
+  /// OAuth Token to call Figma API
+  String figmaOauthToken;
+
+  /// API key needed to do API calls
   String figmaKey;
 
   /// Project ID on Figma

--- a/lib/interpret_and_optimize/services/design_to_pbdl/figma_to_pbdl_service.dart
+++ b/lib/interpret_and_optimize/services/design_to_pbdl/figma_to_pbdl_service.dart
@@ -11,7 +11,8 @@ class FigmaToPBDLService implements DesignToPBDLService {
   Future<PBDLProject> callPBDL(MainInfo info) {
     return PBDL.fromFigma(
       info.figmaProjectID,
-      info.figmaKey,
+      key: info.figmaKey,
+      oauthKey: info.figmaOauthToken,
       outputPath: p.join(info.genProjectPath, 'lib', 'assets'),
       // Generating all assets inside lib folder for package isolation
       pngPath: p.join(info.genProjectPath, 'lib', 'assets', 'images'),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,6 +55,7 @@ final parser = ArgParser()
     help:
         'Takes in a Parabeac Design Logic (PBDL) JSON file and exports it to a project',
   )
+  ..addOption('oauth', help: 'Figma OAuth Token')
   ..addFlag('help',
       help: 'Displays this help information.', abbr: 'h', negatable: false)
   ..addFlag('export-pbdl',
@@ -265,6 +266,7 @@ void collectArguments(ArgResults arguments) {
   /// Detect platform
   info.platform = Platform.operatingSystem;
 
+  info.figmaOauthToken = arguments['oauth'];
   info.figmaKey = arguments['figKey'];
   info.figmaProjectID = arguments['fig'];
 
@@ -296,7 +298,8 @@ void collectArguments(ArgResults arguments) {
 /// is [DesignType.PBDL].Finally, if none of the [DesignType] applies, its going to default
 /// to [DesignType.UNKNOWN].
 DesignType determineDesignTypeFromArgs(ArgResults arguments) {
-  if (arguments['figKey'] != null && arguments['fig'] != null) {
+  if ((arguments['figKey'] != null || arguments['oauth'] != null) &&
+      arguments['fig'] != null) {
     return DesignType.FIGMA;
   } else if (arguments['path'] != null) {
     return DesignType.SKETCH;
@@ -383,7 +386,7 @@ void addToAmplitude() async {
 /// types of intake to parabeac-core
 bool hasTooManyArgs(ArgResults args) {
   var hasSketch = args['path'] != null;
-  var hasFigma = args['figKey'] != null || args['fig'] != null;
+  var hasFigma = args['figKey'] != null || args['fig'] != null || args['oauth'];
   var hasPbdl = args['pbdl-in'] != null;
 
   var hasAll = hasSketch && hasFigma && hasPbdl;
@@ -395,7 +398,8 @@ bool hasTooManyArgs(ArgResults args) {
 /// to parabeac-core
 bool hasTooFewArgs(ArgResults args) {
   var hasSketch = args['path'] != null;
-  var hasFigma = args['figKey'] != null && args['fig'] != null;
+  var hasFigma =
+      (args['figKey'] != null || args['oauth'] != null) && args['fig'] != null;
   var hasPbdl = args['pbdl-in'] != null;
 
   return !(hasSketch || hasFigma || hasPbdl);


### PR DESCRIPTION
If the user wants to use an OAuth token from figma, they can do so via the `--oauth` command argument. If both OAuth and Personal Access Tokens are given, OAuth will be used.